### PR TITLE
 Add a rake task that can be used for local development to setup an admin user

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,4 @@ Rails:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+    - 'lib/tasks/**/*'

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ $ bin/rails console
 # irb(main):001:0>
 ```
 
+### Creating a local admin user
+
+```sh
+$ bin/rails agg:create_admin
+```
 
 ## Misc
 * How to run the test suite

--- a/lib/tasks/admin_tasks.rake
+++ b/lib/tasks/admin_tasks.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+namespace :agg do
+  desc 'Create an initial admin user'
+  task create_admin: :environment do
+    puts 'Creating an initial admin user.'
+    u = prompt_to_create_user
+
+    u.add_role(:admin)
+    puts 'User created.'
+  end
+
+  def prompt_to_create_user
+    User.find_or_create_by!(email: prompt_for_email) do |u|
+      puts 'User not found. Enter a password to create the user.'
+      u.password = prompt_for_password
+    end
+  rescue StandardError => e
+    puts e
+    retry
+  end
+
+  def prompt_for_email
+    print 'Email: '
+    $stdin.gets.chomp
+  end
+
+  def prompt_for_password
+    begin
+      system 'stty -echo'
+      print 'Password (must be 8+ characters): '
+      password = $stdin.gets.chomp
+      puts "\n"
+    ensure
+      system 'stty echo'
+    end
+    password
+  end
+end


### PR DESCRIPTION
Mostly cribbed from the approach in Spotlight: https://github.com/projectblacklight/spotlight/blob/master/lib/tasks/spotlight_tasks.rake

Added for local development convenience