### PR TITLE
Check if the user can create an instance of an Organization

### DIFF
--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -22,5 +22,5 @@
 
   <br>
 
-  <%= link_to 'New Organization', new_organization_path, class: 'btn btn-primary' if can? :create, Organization %>
+  <%= link_to 'New Organization', new_organization_path, class: 'btn btn-primary' if can? :create, Organization.new %>
 </div>


### PR DESCRIPTION
Because we currently define the ability to manage organizations based on
it having a particular ID, the can? :create call needs an instance to
know if the user can in fact create the resource or not.