### PR TITLE
Use the updated_at timestamp of the token to determine if it has been used

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,6 +4,7 @@
 class Ability
   include CanCan::Ability
 
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def initialize(user, token = nil)
     return unless user || token
 
@@ -22,6 +23,7 @@ class Ability
 
       can %i[create read update], [Stream, Upload, Batch], organization: { allowlisted_jwts: { jti: token_payload['jti'] } }
 
+      AllowlistedJwt.find_by(jti: token_payload['jti'])&.update(updated_at: Time.zone.now)
       return
     end
 
@@ -36,4 +38,5 @@ class Ability
     can :invite, Organization, id: member_orgs
     can :manage, [Stream, Upload, Batch], organization: { id: member_orgs }
   end
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/app/models/allowlisted_jwt.rb
+++ b/app/models/allowlisted_jwt.rb
@@ -10,6 +10,13 @@ class AllowlistedJwt < ApplicationRecord
     @encoded_token ||= JWT.encode({ jti: jti }, Settings.jwt.secret, Settings.jwt.algorithm)
   end
 
+  def last_used
+    return unless updated_at
+    return if created_at == updated_at
+
+    updated_at
+  end
+
   private
 
   def set_default_token_values

--- a/app/views/allowlisted_jwts/index.html.erb
+++ b/app/views/allowlisted_jwts/index.html.erb
@@ -1,25 +1,27 @@
-<h1>Manage tokens</h1>
+<div class="container">
+  <h1>Manage tokens</h1>
 
-<table class="table">
-  <thead>
-    <tr>
-      <th>Token</th>
-      <th colspan="1"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @allowlisted_jwts.each do |token| %>
+  <table class="table">
+    <thead>
       <tr>
-        <td>
-          <%= text_field_tag 'token', token.encoded_token, class: 'text-monospace w-100' %>
-        </td>
-        <td><%= link_to 'Revoke', [@organization, token], method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' if can? :delete, token %></td>
+        <th>Token</th>
+        <th colspan="1"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
 
-<br>
+    <tbody>
+      <% @allowlisted_jwts.each do |token| %>
+        <tr>
+          <td>
+            <%= text_field_tag 'token', token.encoded_token, class: 'text-monospace w-100' %>
+          </td>
+          <td><%= link_to 'Revoke', [@organization, token], method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' if can? :delete, token %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 
-<%= link_to 'Create token', organization_allowlisted_jwts_path(@organization), method: :post, class: 'btn btn-primary' if can? :create, @organization.allowlisted_jwts.build %>
+  <br>
+
+  <%= link_to 'Create token', organization_allowlisted_jwts_path(@organization), method: :post, class: 'btn btn-primary' if can? :create, @organization.allowlisted_jwts.build %>
+</div>

--- a/app/views/allowlisted_jwts/index.html.erb
+++ b/app/views/allowlisted_jwts/index.html.erb
@@ -14,6 +14,14 @@
         <tr>
           <td>
             <%= text_field_tag 'token', token.encoded_token, class: 'text-monospace w-100' %>
+            <i class="small text-muted">
+              Last used:
+              <% if token.last_used %>
+                <b><%= time_ago_in_words(token.last_used) %> ago</b>
+              <% else %>
+                never
+              <% end %>
+            </i>
           </td>
           <td><%= link_to 'Revoke', [@organization, token], method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' if can? :delete, token %></td>
         </tr>

--- a/spec/models/allowlisted_jwt_spec.rb
+++ b/spec/models/allowlisted_jwt_spec.rb
@@ -26,4 +26,17 @@ RSpec.describe AllowlistedJwt do
   it 'cannot be successfully created if not assocated with a resource' do
     expect(described_class.create(jti: 'abc123')).not_to be_persisted
   end
+
+  describe '#last_used' do
+    it 'is nil if the updated and created at times are the same' do
+      expect(described_class.create(resource: organization).last_used).to be_nil
+    end
+
+    it 'is the updated at timestamp if it differs from the created at' do
+      token = described_class.create(resource: organization)
+      token.update(updated_at: Time.zone.now)
+      token.reload
+      expect(token.last_used).to eq token.updated_at
+    end
+  end
 end

--- a/spec/views/allowlisted_jwts/index.html.erb_spec.rb
+++ b/spec/views/allowlisted_jwts/index.html.erb_spec.rb
@@ -19,4 +19,13 @@ RSpec.describe 'allowlisted_jwts/index', type: :view do
     assert_select 'input[value=?]', organization.allowlisted_jwts[0].encoded_token
     assert_select 'input[value=?]', organization.allowlisted_jwts[1].encoded_token
   end
+
+  it 'renders if the token has been used or not' do
+    organization.allowlisted_jwts.last.update(updated_at: Time.zone.now)
+
+    render
+
+    assert_select 'i.text-muted', /Last used:\s+never/
+    assert_select 'i.text-muted', /Last used:\s+less than a minute ago/
+  end
 end


### PR DESCRIPTION
Update that timestamp when a token has been used for access and display that information on the dashboard.

This updated_at strategy likely won't work if we add other data (like a name/label), but just thought I would throw this up to start the convo on how we might want to approach this.

<img width="1156" alt="Screen Shot 2020-11-02 at 10 00 04 AM" src="https://user-images.githubusercontent.com/96776/97902832-fdc2d680-1cf2-11eb-84c1-af972e6c9946.png">
