### PR TITLE
Setup sidekiq to run jobs in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ gem 'rolify'
 gem 'sidekiq'
 gem 'inline_svg'
 gem 'marc'
+gem 'sidekiq'
 
 group :deployment do
   gem 'capistrano', '~> 3.0'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,3 +33,11 @@ set :linked_dirs, %w(storage log tmp/pids tmp/cache tmp/sockets vendor/bundle pu
 
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, "#{fetch(:stage)}"
+
+namespace :deploy do
+  after :restart, :restart_sidekiq do
+    on roles(:background) do
+      sudo :systemctl, "restart", "sidekiq-*", raise_on_non_zero_exit: false
+    end
+  end
+end

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,4 +1,5 @@
-server 'pod.stanford.edu', user: 'pod', roles: %w(web db app)
+server 'pod.stanford.edu', user: 'pod', roles: %w(web db app background)
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'
+set :sidekiq_roles, :background

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  config.active_job.queue_adapter     = :sidekiq
   # config.active_job.queue_name_prefix = "aggregator_production"
 
   config.action_mailer.perform_caching = false

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -7,3 +7,7 @@ ActiveStorage::Engine
 
 Rails.application.config.active_storage.analyzers.append BinaryMarcAnalyzer
 Rails.application.config.active_storage.analyzers.append XmlMarcAnalyzer
+
+# Use default queue for analysis and purge for Sidekiq simplification
+Rails.application.config.active_storage.queues[:analysis] = :default
+Rails.application.config.active_storage.queues[:purge] = :default

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,3 @@
+Sidekiq.configure_server do |config|
+  config.logger.level = Object.const_get(Settings.sidekiq.logger_level)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,10 @@ Rails.application.routes.draw do
   end
 
   resources :site_users, only: [:index, :update]
+
+  authenticate :user, lambda { |u| u.has_role? :admin } do
+    require 'sidekiq/web'
+    Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
+    mount Sidekiq::Web => '/sidekiq'
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,5 @@
 jwt:
   secret: 'i♥️dolphins'
   algorithm: 'HS256'
+sidekiq:
+  logger_level: 'Logger::INFO' # The default from Sidekiq


### PR DESCRIPTION
Sets up sidekiq to be the job running in production.

However, this may unveil a race condition not previously noticed. Whereas, the `after_commit` in `Upload` may enqueue itself and be ran before analysis has completed.

https://github.com/ivplus/aggregator/blob/main/app/models/upload.rb#L12-L14

We should handle this probably in the ExtractMarcRecordMetadataJob. 