### PR TITLE
Add the bundler cache to the CI build

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,6 +21,14 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+    - name: Bundle install
+      run: bundle config path vendor/bundle
     - name: Install dependencies
       run: bin/setup
     - name: Compile webpack assets


### PR DESCRIPTION
This reduces the build time from ~5 minutes to ~1 minute.