### PR TITLE
Allow uploads to get directed at a particular stream

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,6 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Exclude:
     - 'app/models/ability.rb'
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10

--- a/app/controllers/streams_controller.rb
+++ b/app/controllers/streams_controller.rb
@@ -10,4 +10,18 @@ class StreamsController < ApplicationController
   def removed_since_previous_stream
     render plain: @stream.removed_since_previous_stream.join("\n")
   end
+
+  def make_default
+    @stream = @organization.streams.find(params[:stream])
+
+    Stream.transaction do
+      @organization.default_stream.update(default: false)
+      @stream.update(default: true)
+    end
+
+    respond_to do |format|
+      format.html { redirect_to @organization, notice: 'Stream was successfully updated.' }
+      format.json { render :show, status: :ok, location: @organization }
+    end
+  end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -63,11 +63,17 @@ class UploadsController < ApplicationController
   private
 
   def load_stream
-    @stream = @organization.default_stream
+    @stream = if params[:stream].present?
+                @organization.streams.find_or_create_by(slug: params[:stream]) do |stream|
+                  stream.name = params[:stream]
+                end
+              else
+                @organization.default_stream
+              end
   end
 
   # Only allow a list of trusted parameters through.
   def upload_params
-    params.require(:upload).permit(:name, :stream_id, files: [])
+    params.require(:upload).permit(:name, files: []).tap { |p| p['files'].reject!(&:blank?) }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,10 @@ Rails.application.routes.draw do
     post 'invite', to: 'organization_invitations#create'
     resources :allowlisted_jwts, only: [:index, :create, :destroy]
     resources :streams, only: [:show], defaults: { format: :xml } do
+      collection do
+        post 'make_default'
+      end
+
       member do
         get :removed_since_previous_stream
       end

--- a/spec/requests/streams_controller_spec.rb
+++ b/spec/requests/streams_controller_spec.rb
@@ -22,4 +22,19 @@ RSpec.describe '/organization/:id/stream', type: :request do
       expect(response.body).to include '<rs:md capability="resourceList"'
     end
   end
+
+  describe 'POST /make_default' do
+    let!(:default_stream) { organization.default_stream }
+
+    it 'toggles on the default attribute for the new stream' do
+      post make_default_organization_streams_url(organization_id: stream.organization.id, stream: stream, format: :html)
+      expect(response).to redirect_to(organization_url(stream.organization))
+      expect(stream.reload).to have_attributes default: true
+    end
+
+    it 'toggles off the default stream for the previous default' do
+      post make_default_organization_streams_url(organization_id: stream.organization.id, stream: stream, format: :html)
+      expect(default_stream.reload).to have_attributes default: false
+    end
+  end
 end


### PR DESCRIPTION
Fixes #74 ?

This adds a named `stream` parameter to our upload routes. Clients can make up whatever makes sense to them locally to add uploads to the named stream. After finishing a full upload, clients can use the `make_default` endpoint to say it's ready to go 🤷‍♂️ :

```
curl -X POST -F file=@./part1 /organization/5/uploads?stream=202011
curl -X POST -F file=@./part2 /organization/5/uploads?stream=202011
curl -X POST -F file=@./part3 /organization/5/uploads?stream=202011
curl -X POST -F file=@./20201031-nightly /organization/5/uploads
curl -X POST -F file=@./part4 /organization/5/uploads?stream=202011
curl -X POST -F file=@./part5 /organization/5/uploads?stream=202011
curl -X POST /organization/5/streams/make_default?stream=202011
```