### PR TITLE
Support PUT requests to create new uploads with a given slug

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -3,6 +3,8 @@
 # :nodoc:
 class Upload < ApplicationRecord
   has_paper_trail
+  extend FriendlyId
+  friendly_id :name, use: %i[finders slugged scoped], scope: %i[stream]
   belongs_to :stream, touch: true
   has_one :organization, through: :stream
   has_many :marc_records, dependent: :delete_all

--- a/db/migrate/20201105045358_add_slug_to_upload.rb
+++ b/db/migrate/20201105045358_add_slug_to_upload.rb
@@ -1,0 +1,6 @@
+class AddSlugToUpload < ActiveRecord::Migration[6.0]
+  def change
+    add_column :uploads, :slug, :string
+    add_index :uploads, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_04_143930) do
+ActiveRecord::Schema.define(version: 2020_11_05_045358) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -117,6 +117,8 @@ ActiveRecord::Schema.define(version: 2020_11_04_143930) do
     t.integer "stream_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "slug"
+    t.index ["slug"], name: "index_uploads_on_slug"
     t.index ["stream_id"], name: "index_uploads_on_stream_id"
   end
 


### PR DESCRIPTION
:shrug:

If nothing else, it allows clients to use more shorthand (but also.. aligns with REST?):

curl -T whatever.marc -H 'Authorization: Bearer ...' http://127.0.0.1:3000/organizations/3/uploads/whatever.marc



