### PR TITLE
Cache organization + stream statistics in a table

### DIFF
--- a/app/jobs/extract_marc_record_metadata_job.rb
+++ b/app/jobs/extract_marc_record_metadata_job.rb
@@ -15,5 +15,7 @@ class ExtractMarcRecordMetadataJob < ApplicationJob
         # rubocop:enable Rails/SkipsModelValidations
       end
     end
+
+    UpdateOrganizationStatisticsJob.perform_later(upload.organization, upload.stream)
   end
 end

--- a/app/jobs/update_organization_statistics_job.rb
+++ b/app/jobs/update_organization_statistics_job.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Calculate some daily statistics for an organization
+class UpdateOrganizationStatisticsJob < ApplicationJob
+  queue_as :default
+
+  def perform(organization, stream = nil)
+    stream ||= organization.default_stream
+
+    stream_statistics = stream.statistic || stream.create_statistic
+    stream_statistics.update(date: Time.zone.today, **calculate_stream_statistics(stream))
+
+    org_statistics = organization.statistics.find_or_initialize_by(date: Time.zone.today)
+
+    org_statistics.update(
+      date: Time.zone.today,
+      **calculate_organization_statistics(organization)
+    )
+  end
+
+  def calculate_organization_statistics(context)
+    {
+      unique_record_count: context.marc_records.distinct.count(:marc001),
+      record_count: context.marc_records.size,
+      file_count: context.default_stream&.statistic&.file_count,
+      file_size: context.default_stream&.statistic&.file_size
+    }
+  end
+
+  def calculate_stream_statistics(context)
+    {
+      unique_record_count: context.marc_records.distinct.count(:marc001),
+      record_count: context.marc_records.size,
+      file_size: context.files.sum(:byte_size),
+      file_count: context.files.size
+    }
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -13,6 +13,7 @@ class Organization < ApplicationRecord
   has_one_attached :icon
   has_many_attached :full_dump_binary
   has_many_attached :full_dump_xml
+  has_many :statistics, dependent: :delete_all, as: :resource
 
   def default_stream
     @default_stream ||= streams.find_or_create_by(default: true)
@@ -20,5 +21,9 @@ class Organization < ApplicationRecord
 
   def jwt_token
     @jwt_token ||= allowlisted_jwts.first_or_create.encoded_token
+  end
+
+  def latest_statistics
+    statistics.latest.first_or_initialize
   end
 end

--- a/app/models/statistic.rb
+++ b/app/models/statistic.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Time-based statistics or an organization
+class Statistic < ApplicationRecord
+  scope :latest, -> { order(date: :desc).limit(1) }
+  belongs_to :resource
+end

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -9,6 +9,7 @@ class Stream < ApplicationRecord
   has_many :uploads, dependent: :destroy
   has_many :marc_records, through: :uploads
   has_many :files, source: :files_blobs, through: :uploads
+  has_one :statistic, dependent: :delete, as: :resource
 
   has_many_attached :snapshots
 

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -23,7 +23,7 @@
           </td>
           <td><%= organization.default_stream.files.size %> | <%= number_to_human_size organization.default_stream.files.sum(:byte_size) %></td>
           <td><%= organization.default_stream.uploads.last&.updated_at %></td>
-          <td><%= number_with_delimiter organization.marc_records.distinct.count(:marc001) %> unique (<%= number_with_delimiter organization.marc_records.size %> total)</td>
+          <td><%= number_with_delimiter organization.latest_statistics.unique_record_count %> unique (<%= number_with_delimiter organization.latest_statistics.record_count %> total)</td>
           <td><%= link_to 'Edit', edit_organization_path(organization), class: 'btn btn-secondary' if can? :edit, organization %></td>
           <td><%= link_to 'Destroy', organization, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' if can? :delete, organization %></td>
         </tr>
@@ -32,7 +32,7 @@
         <td></td>
         <td><%= number_with_delimiter(@organizations.sum {|org| org.default_stream.files.size }) %> | <%= number_to_human_size @organizations.sum {|org| org.default_stream.files.sum(:byte_size)} %></td>
         <td></td>
-        <td><%= number_with_delimiter(@organizations.sum {|org| org.marc_records.distinct.count(:marc001)}) %> unique (<%= number_with_delimiter(@organizations.sum {|org| org.marc_records.size })%> total)</td>
+        <td><%= number_with_delimiter(@organizations.sum { |org| org.latest_statistics.unique_record_count }) %> unique (<%= number_with_delimiter(@organizations.sum { |org| org.latest_statistics.record_count })%> total)</td>
       </tr>
     </tbody>
   </table>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -14,7 +14,7 @@
       Last updated: <%= @organization.default_stream.uploads.last&.updated_at %>
     </p>
     <p class="lead">
-      Records: <%= number_with_delimiter @organization.marc_records.distinct.count(:marc001) %> unique (<%= number_with_delimiter @organization.marc_records.count %> total)
+      Records: <%= number_with_delimiter @organization.latest_statistics.unique_record_count %> unique (<%= number_with_delimiter @organization.latest_statistics.record_count %> total)
     </p>
   </div>
 </div>
@@ -22,7 +22,7 @@
 <div class="container">
   <div class="card">
     <div class="card-header d-flex justify-content-between">
-      <h2>Stream <%= @organization.default_stream.display_name %> (<%= number_with_delimiter @organization.default_stream.marc_records.distinct.count(:marc001) %> records)</h2>
+      <h2>Stream <%= @organization.default_stream.display_name %> (<%= @organization.default_stream.statistic&.unique_record_count %> records)</h2>
     </div>
     <div class="card-header d-flex justify-content-between">
       <h3 class="h5 align-self-center mb-0">Files (<%= number_with_delimiter @organization.default_stream.files.size %> | <%= number_to_human_size @organization.default_stream.files.sum(:byte_size) %>)</h3>

--- a/db/migrate/20201105184543_create_statistics.rb
+++ b/db/migrate/20201105184543_create_statistics.rb
@@ -1,0 +1,16 @@
+class CreateStatistics < ActiveRecord::Migration[6.0]
+  def change
+    create_table :statistics do |t|
+      t.references :resource, null: false, index: true, polymorphic: true
+      t.bigint :unique_record_count, default: 0
+      t.bigint :record_count, default: 0
+      t.bigint :file_size, default: 0
+      t.bigint :file_count, default: 0
+      t.date :date
+
+      t.timestamps
+    end
+
+    add_index :statistics, [:resource_type, :resource_id, :date]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_04_143930) do
+ActiveRecord::Schema.define(version: 2020_11_05_184543) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -101,6 +101,20 @@ ActiveRecord::Schema.define(version: 2020_11_04_143930) do
     t.index ["resource_type", "resource_id"], name: "index_roles_on_resource_type_and_resource_id"
   end
 
+  create_table "statistics", force: :cascade do |t|
+    t.string "resource_type", null: false
+    t.integer "resource_id", null: false
+    t.bigint "unique_record_count", default: 0
+    t.bigint "record_count", default: 0
+    t.bigint "file_size", default: 0
+    t.bigint "file_count", default: 0
+    t.date "date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["resource_type", "resource_id", "date"], name: "index_statistics_on_resource_type_and_resource_id_and_date"
+    t.index ["resource_type", "resource_id"], name: "index_statistics_on_resource_type_and_resource_id"
+  end
+
   create_table "streams", force: :cascade do |t|
     t.string "name"
     t.integer "organization_id"
@@ -117,6 +131,8 @@ ActiveRecord::Schema.define(version: 2020_11_04_143930) do
     t.integer "stream_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "slug"
+    t.index ["slug"], name: "index_uploads_on_slug"
     t.index ["stream_id"], name: "index_uploads_on_stream_id"
   end
 

--- a/spec/factories/organization_statistics.rb
+++ b/spec/factories/organization_statistics.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :organization_statistic do
+    organization { nil }
+    unique_record_count { '' }
+    record_count { '' }
+    file_size { '' }
+    file_count { '' }
+    date { '2020-11-05' }
+  end
+end

--- a/spec/jobs/extract_marc_record_metadata_job_spec.rb
+++ b/spec/jobs/extract_marc_record_metadata_job_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe ExtractMarcRecordMetadataJob, type: :job do
 
     expect(MarcRecord.last).to have_attributes marc001: 'a1297245', bytecount: 0, length: 1407, index: 0
   end
+
+  it 'enqueues the stats job' do
+    expect do
+      described_class.perform_now(upload)
+    end.to enqueue_job(UpdateOrganizationStatisticsJob)
+  end
 end

--- a/spec/jobs/update_organization_statistics_job_spec.rb
+++ b/spec/jobs/update_organization_statistics_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UpdateOrganizationStatisticsJob, type: :job do
+  let(:organization) { FactoryBot.create(:organization) }
+
+  before do
+    organization.default_stream.uploads << FactoryBot.build(:upload, :binary_marc)
+    organization.default_stream.uploads << FactoryBot.build(:upload, :binary_marc)
+    organization.default_stream.uploads << FactoryBot.build(:upload, :binary_marc)
+
+    # populate the MarcRecords index
+    organization.default_stream.uploads.each { |u| ExtractMarcRecordMetadataJob.perform_now(u) }
+  end
+
+  it 'calculates organization-level statistics' do
+    described_class.perform_now(organization)
+
+    expect(organization.latest_statistics).to have_attributes(
+      record_count: 3, unique_record_count: 1,
+      file_count: 3, file_size: 4221
+    )
+  end
+
+  it 'calculates stream-level statistics' do
+    described_class.perform_now(organization)
+
+    expect(organization.default_stream.statistic).to have_attributes(
+      record_count: 3, unique_record_count: 1,
+      file_count: 3, file_size: 4221
+    )
+  end
+end

--- a/spec/models/statistic_spec.rb
+++ b/spec/models/statistic_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Statistic, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This should increase performance on organizations#index and #show so we don't need to recalculate all the stats every page load. It also sets us up for some graphs over time 🤷‍♂️ 