### PR TITLE
Homepage content and general styling updates

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,20 @@
 @import 'logo';
 @import 'rails_bootstrap_forms';
 
+$footer-height: 176px;
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  position: relative;
+
+  &::after {
+    content: '';
+    display: block;
+    height: $footer-height;
+  }
+}
+
 #hero {
   .bg-image {
     width: 100%;
@@ -72,4 +86,13 @@
 
 input[type=file][data-direct-upload-url][disabled] {
   display: none;
+}
+
+.footer {
+  background-color: #f8f9fa;
+  border-top: 1px solid darken(#f8f9fa, 10%);
+  bottom: 0;
+  height: $footer-height;
+  position: absolute;
+  width: 100%;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -88,6 +88,10 @@ input[type=file][data-direct-upload-url][disabled] {
   display: none;
 }
 
+.index-page {
+  margin-top: 2rem;
+}
+
 .footer {
   background-color: #f8f9fa;
   border-top: 1px solid darken(#f8f9fa, 10%);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,15 +28,12 @@
     background-image: image-url('hero.jpg');
     background-size: contain;
     top: 0; bottom: 0; left: 0; right: 0;
-    filter:blur(3.5px) brightness(50%) sepia()  hue-rotate(160deg);
+    filter:blur(3.5px) brightness(50%) sepia(50%)  hue-rotate(160deg);
   }
 
-  margin-top: -0.5rem;
-
-  .hero-text {
-    border-radius: 20px;
+  .lead {
+    font-size: 1.25rem;
   }
-  .lead { font-size: 1.5rem; }
 }
 
 .direct-upload {

--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -7,5 +7,11 @@
 .organization {
   .organization-icon {
     height: 50px;
+    padding-right: 0.5rem;
+    vertical-align: bottom;
+  }
+
+  .lead {
+    margin-bottom: 0.25rem;
   }
 }

--- a/app/views/dashboard/uploads.html.erb
+++ b/app/views/dashboard/uploads.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container index-page">
   <h1>Uploads</h1>
 
   <% unless params[:page] %>
@@ -16,8 +16,7 @@
   <table class="table">
     <thead>
       <tr>
-        <th></th>
-        <th>Organization</th>
+        <th colspan="2">Organization</th>
         <th>Name</th>
         <th>Updated</th>
         <th class="text-right">File count</th>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,11 +1,10 @@
-<div class="container">
+<div class="container index-page">
   <h1>Organizations</h1>
 
   <table class="table table-striped organizations">
     <thead>
       <tr>
-        <th></th>
-        <th>Name</th>
+        <th colspan="2">Name</th>
         <th style="width: 6ch;" class="text-right">Files</th>
         <th class="text-right">Size</th>
         <th class="text-right">Unique records</th>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -30,14 +30,14 @@
         </div>
         <div class="card-body">
           <p>Tokens you have generated that can be used to access the POD API.</p>
-          <%= link_to 'Manage tokens', organization_allowlisted_jwts_path(@organization), class: 'btn btn-primary' if can? :create, @organization.allowlisted_jwts.build %>
+          <%= link_to 'Manage tokens', organization_allowlisted_jwts_path(@organization), class: 'btn btn-sm btn-primary' if can? :create, @organization.allowlisted_jwts.build %>
         </div>
       </div>
 
       <div class="card my-5">
         <div class="card-header d-flex justify-content-between">
           <h2 class="h5 align-self-center mb-0">Users</h2>
-          <%= link_to 'Invite', organization_invite_new_path(@organization), class: 'btn btn-primary' if can? :invite, @organization %>
+          <%= link_to 'Invite', organization_invite_new_path(@organization), class: 'btn btn-sm btn-primary' if can? :invite, @organization %>
         </div>
 
         <ul class="list-group list-group-flush">
@@ -62,7 +62,7 @@
       <div class="card">
         <div class="card-header d-flex justify-content-between">
           <h2 class="h5 align-self-center mb-0">Contact emails</h2>
-          <%= link_to 'Add', new_organization_contact_email_path(@organization), class: 'btn btn-primary' if can? :manage, @organization %>
+          <%= link_to 'Add', new_organization_contact_email_path(@organization), class: 'btn btn-sm btn-primary' if can? :manage, @organization %>
         </div>
 
         <ul class="list-group list-group-flush">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,11 +1,30 @@
 <div id="hero" class="position-relative overflow-hidden p-3 p-md-5 text-center bg-dark text-light">
   <div class="bg-image"></div>
-  <div class="hero-text col-md-7 p-lg-5 mx-auto my-5">
+  <div class="hero-text col-md-7 p-lr-3 mx-auto my-4">
     <h1 class="display-4 font-weight-normal mb-5">POD Data Lake <span class="badge badge-info">MVP</span></h1>
     <p class="lead font-weight-normal">
-      The POD Data Transfer MVP will produce a openly developed minimum viable product to receive and transmit MARC bibliographic and holdings data from multiple institutions.
+      The POD Data Transfer MVP will produce a openly developed minimum viable product to receive and transmit MARC bibliographic and holdings data from multiple institutions
     </p>
   </div>
-  <div class="product-device shadow-sm d-none d-md-block"></div>
-  <div class="product-device product-device-2 shadow-sm d-none d-md-block"></div>
+</div>
+
+<div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
+  <div class="mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
+    <div class="my-3 py-3">
+      <h2 class="display-5">MVP Goal</h2>
+      <p class="lead">Support receiving and transmitting both full dumps and delta change sets</p>
+    </div>
+  </div>
+  <div class="mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
+    <div class="my-3 p-3">
+      <h2 class="display-5">MVP Goal</h2>
+      <p class="lead">Enable external normalization, analysis, and discovery indexing, and basic reporting and data reconciliation</p>
+    </div>
+  </div>
+  <div class="mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
+    <div class="my-3 p-3">
+      <h2 class="display-5">MVP Goal</h2>
+      <p class="lead">Help POD refine and develop operational models for a service based on the MVP</p>
+    </div>
+  </div>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,36 +1,36 @@
-<footer class="container py-5">
-  <div class="row">
-    <div class="col-12 col-md">
-      <%= inline_svg_pack_tag 'media/packs/images/pod_small.svg', width: 30, height: 30, aria_hidden: true, class: 'pod-logo-small' %>
-      <small class="d-block mb-3 text-muted">&copy; 2020</small>
-    </div>
-    <div class="col-6 col-md">
-      <h5>Features</h5>
-      <ul class="list-unstyled text-small">
-        <li><a class="text-muted" href="#">Cool stuff</a></li>
-        <li><a class="text-muted" href="#">Random feature</a></li>
-        <li><a class="text-muted" href="#">Team feature</a></li>
-        <li><a class="text-muted" href="#">Stuff for developers</a></li>
-        <li><a class="text-muted" href="#">Another one</a></li>
-        <li><a class="text-muted" href="#">Last time</a></li>
-      </ul>
-    </div>
-    <div class="col-6 col-md">
-      <h5>Resources</h5>
-      <ul class="list-unstyled text-small">
-        <li>
-          <%= link_to 'API documentation', api_path, class: 'text-muted' %>
-        </li>
-      </ul>
-    </div>
-    <div class="col-6 col-md">
-      <h5>About</h5>
-      <ul class="list-unstyled text-small">
-        <li><a class="text-muted" href="#">Team</a></li>
-        <li><a class="text-muted" href="#">Locations</a></li>
-        <li><a class="text-muted" href="#">Privacy</a></li>
-        <li><a class="text-muted" href="#">Terms</a></li>
-      </ul>
+<footer class="footer p-4">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 col-md">
+        <%= inline_svg_pack_tag 'media/packs/images/pod_small.svg', width: 30, height: 30, aria_hidden: true, class: 'pod-logo-small' %>
+        <small class="d-block mb-3 mt-2 text-muted">&copy; 2020</small>
+      </div>
+      <div class="col-6 col-md">
+        <h5>Features</h5>
+        <ul class="list-unstyled text-small">
+          <li><a class="text-muted" href="#">Cool stuff</a></li>
+          <li><a class="text-muted" href="#">Random feature</a></li>
+          <li><a class="text-muted" href="#">Team feature</a></li>
+          <li><a class="text-muted" href="#">Stuff for developers</a></li>
+        </ul>
+      </div>
+      <div class="col-6 col-md">
+        <h5>Resources</h5>
+        <ul class="list-unstyled text-small">
+          <li>
+            <%= link_to 'API documentation', api_path, class: 'text-muted' %>
+          </li>
+        </ul>
+      </div>
+      <div class="col-6 col-md">
+        <h5>About</h5>
+        <ul class="list-unstyled text-small">
+          <li><a class="text-muted" href="#">Team</a></li>
+          <li><a class="text-muted" href="#">Locations</a></li>
+          <li><a class="text-muted" href="#">Privacy</a></li>
+          <li><a class="text-muted" href="#">Terms</a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </footer>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-dark navbar-expand bg-dark mb-2" role="navigation">
+<nav class="navbar navbar-dark navbar-expand bg-dark" role="navigation">
   <div class="container px-3">
     <%= link_to root_url, class: 'navbar-brand' do %>
       <%= inline_svg_pack_tag 'media/packs/images/pod_logo.svg', height: 30, width: 80 %> Aggregator

--- a/app/views/shared/_organization_header.html.erb
+++ b/app/views/shared/_organization_header.html.erb
@@ -1,7 +1,7 @@
-<div class="position-relative overflow-hidden mb-3 bg-light organization">
+<div class="position-relative overflow-hidden mb-5 pb-2 pt-4 bg-light organization">
   <div class="container">
     <div class="d-flex justify-content-between">
-      <h1 class="display-4 font-weight-normal">
+      <h1 class="display-5 font-weight-normal mb-3">
         <% if @organization.icon.attached? %>
           <%= image_tag(@organization.icon, class: 'organization-icon') %>
         <% end %>

--- a/app/views/site_users/index.html.erb
+++ b/app/views/site_users/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container index-page">
   <h1>Site users</h1>
 
   <table class="table table-striped">

--- a/app/views/streams/_stream_uploads.html.erb
+++ b/app/views/streams/_stream_uploads.html.erb
@@ -4,7 +4,7 @@
     <%= link_to 'Upload file', new_organization_upload_path(@organization), class: 'btn btn-primary' %>
   </div>
 
-  <table class="table table-striped">
+  <table class="table table-striped mb-0">
     <thead><th class="pl-4">File</th><th>Date created</th><th>Size</th><th>Content type</th><th class="text-right pr-4">Records</th></thead>
     <tbody>
     <% stream.uploads.each_with_index do |upload, ix| %>


### PR DESCRIPTION
- Adds some content to the homepage, mostly because it seems weird to have just a hero section and a footer
- Made the site footer sticky to the bottom of the viewport and gave it a background color to contrast with content page background
- Made some updates to spacing on various pages, such as providing some vertical space between the bottom of the top nav and the start of the page content

Homepage screenshot (note that I got the text for the "MVP Goals" from the project inception deck, but we could easily remove or edit this text as the project team wants). 

<img width="1128" alt="Screen Shot 2020-11-09 at 3 42 43 PM" src="https://user-images.githubusercontent.com/101482/98606946-638c0100-22a5-11eb-873a-3a38c74a3dbb.png">
