### PR TITLE
Build out resourcesync sitemaps for XML + binary normalized dumps

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,7 @@ Metrics/ClassLength:
 
 Metrics/BlockLength:
   Exclude:
+    - 'app/views/**/*.builder'
     - 'spec/**/*'
     - 'lib/tasks/**/*'
 

--- a/app/controllers/resourcesync_controller.rb
+++ b/app/controllers/resourcesync_controller.rb
@@ -7,4 +7,6 @@ class ResourcesyncController < ApplicationController
   def source_description; end
 
   def capabilitylist; end
+
+  def normalized_capabilitylist; end
 end

--- a/app/controllers/streams_controller.rb
+++ b/app/controllers/streams_controller.rb
@@ -24,6 +24,10 @@ class StreamsController < ApplicationController
     end
   end
 
+  def normalized_dump
+    @normalized_dump = @stream.normalized_dumps.last || @stream.normalized_dumps.build
+  end
+
   def destroy
     @stream.destroy
 

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -50,4 +50,19 @@
   <br>
 
   <%= link_to 'New Organization', new_organization_path, class: 'btn btn-primary' if can? :create, Organization.new %>
+
+  <hr />
+
+  <h1>Harvesting</h1>
+
+  <div class="card w-50">
+    <div class="card-header d-flex justify-content-between">
+      <h2 class="h6">ResourceSync sitemaps</h2>
+    </div>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item"><%= link_to 'Original uploads', resourcelist_organizations_url %> (real-time)</li>
+      <li class="list-group-item"><%= link_to 'Normalized uploads as MARCXML', normalized_resourcelist_organizations_url(flavor: 'marcxml') %> (updated nightly)</li>
+      <li class="list-group-item"><%= link_to 'Normalized uploads as MARC21', normalized_resourcelist_organizations_url(flavor: 'marc21') %> (updated nightly)</li>
+    </ul>
+  </div>
 </div>

--- a/app/views/resourcesync/normalized_capabilitylist.xml.builder
+++ b/app/views/resourcesync/normalized_capabilitylist.xml.builder
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.urlset(
+  'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+  'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
+  'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+  'xmlns:rs' => 'http://www.openarchives.org/rs/terms/'
+) do
+  xml.tag!('rs:ln', rel: 'up', href: resourcesync_source_description_url)
+  xml.tag!('rs:md', capability: 'capabilitylist')
+
+  xml.url do
+    xml.loc normalized_resourcelist_organizations_url(flavor: params[:flavor])
+    xml.tag!('rs:md', capability: 'resourcelist')
+  end
+end

--- a/app/views/resourcesync/source_description.xml.builder
+++ b/app/views/resourcesync/source_description.xml.builder
@@ -13,4 +13,14 @@ xml.urlset(
     xml.loc resourcesync_capabilitylist_url
     xml.tag!('rs:md', capability: 'capabilitylist')
   end
+
+  xml.url do
+    xml.loc resourcesync_normalized_dump_capabilitylist_url(flavor: 'marcxml')
+    xml.tag!('rs:md', capability: 'capabilitylist')
+  end
+
+  xml.url do
+    xml.loc resourcesync_normalized_dump_capabilitylist_url(flavor: 'marc21')
+    xml.tag!('rs:md', capability: 'capabilitylist')
+  end
 end

--- a/app/views/streams/normalized_dump.xml.builder
+++ b/app/views/streams/normalized_dump.xml.builder
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.urlset(
+  'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+  'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
+  'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+  'xmlns:rs' => 'http://www.openarchives.org/rs/terms/'
+) do
+  xml.tag!('rs:ln', rel: 'up', href: normalized_resourcelist_organizations_url)
+  xml.tag!('rs:md', capability: 'resourcelist', at: @normalized_dump.updated_at&.iso8601)
+
+  if @normalized_dump.persisted?
+    xml.url(removed_since_previous_stream_organization_stream_url(@stream))
+
+    full = if params[:flavor] == 'marc21'
+             @normalized_dump.full_dump_binary
+           else
+             @normalized_dump.full_dump_xml
+           end
+
+    xml.url do
+      xml.tag!(
+        'rs:md',
+        hash: "md5:#{Base64.decode64(full.checksum).unpack1('H*')}",
+        type: full.content_type,
+        length: full.byte_size
+      )
+      xml.loc(download_url(full))
+      xml.lastmod(full.created_at.iso8601)
+    end
+
+    # deltas
+
+    deltas = if params[:flavor] == 'marc21'
+               @normalized_dump.delta_dump_binary
+             else
+               @normalized_dump.delta_dump_xml
+             end
+
+    deltas.each do |file|
+      xml.url do
+        xml.tag!(
+          'rs:md',
+          hash: "md5:#{Base64.decode64(file.checksum).unpack1('H*')}",
+          type: file.content_type,
+          length: file.byte_size
+        )
+        xml.loc(download_url(file))
+        xml.lastmod(file.created_at.iso8601)
+      end
+    end
+  end
+end

--- a/app/views/streams/show.xml.builder
+++ b/app/views/streams/show.xml.builder
@@ -19,7 +19,7 @@ xml.urlset(
         length: file.byte_size
       )
       xml.loc(download_url(file))
-      xml.lastmod(file.created_at)
+      xml.lastmod(file.created_at.iso8601)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   get '/.well-known/resourcesync', to: 'resourcesync#source_description', as: :resourcesync_source_description, defaults: { format: :xml }
   get '/.well-known/resourcesync/capabilitylist', to: 'resourcesync#capabilitylist', as: :resourcesync_capabilitylist, defaults: { format: :xml }
+  get '/.well-known/resourcesync/normalized-capabilitylist/:flavor', to: 'resourcesync#normalized_capabilitylist', as: :resourcesync_normalized_dump_capabilitylist, defaults: { format: :xml }
 
   get 'dashboard/uploads', to: 'dashboard#uploads', as: :activity
   get 'charts/uploads', to: 'charts#uploads', as: :uploads_chart
@@ -17,6 +18,7 @@ Rails.application.routes.draw do
   resources :organizations do
     collection do
       get 'resourcelist', to: 'organizations#index', defaults: { format: :xml }
+      get 'normalized_resourcelist/:flavor', to: 'organizations#index', defaults: { normalized: true, format: :xml }, as: :normalized_resourcelist
     end
     resources :uploads
     resources :organization_users, as: 'users', only: :destroy
@@ -32,6 +34,7 @@ Rails.application.routes.draw do
 
       member do
         get 'resourcelist', to: 'streams#show', defaults: { format: :xml }
+        get 'normalized_resourcelist/:flavor', to: 'streams#normalized_dump', defaults: { format: :xml }, as: :normalized_resourcelist
         get :removed_since_previous_stream
       end
     end

--- a/spec/requests/resourcesync_controller_spec.rb
+++ b/spec/requests/resourcesync_controller_spec.rb
@@ -20,4 +20,11 @@ RSpec.describe '/.well-known/resourcesync', type: :request do
       expect(response.body).to include '<rs:md capability="capabilitylist"'
     end
   end
+
+  describe 'GET /normalized_capabilitylist' do
+    it 'has some resourceSync stuff in it' do
+      get resourcesync_normalized_dump_capabilitylist_url(flavor: 'marcxml')
+      expect(response.body).to include '<rs:md capability="capabilitylist"'
+    end
+  end
 end

--- a/spec/requests/streams_controller_spec.rb
+++ b/spec/requests/streams_controller_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe '/organization/:id/stream', type: :request do
     end
   end
 
+  describe 'GET /normalized_dump' do
+    it 'renders a successful response' do
+      get normalized_resourcelist_organization_stream_path(
+        organization_id: stream.organization.id, id: stream.id, flavor: 'marcxml'
+      )
+      expect(response).to be_successful
+    end
+
+    it 'has some resourceSync stuff in it' do
+      get normalized_resourcelist_organization_stream_path(
+        organization_id: stream.organization.id, id: stream.id, flavor: 'marcxml'
+      )
+      expect(response.body).to include '<rs:md capability="resourcelist"'
+    end
+  end
+
   describe 'POST /make_default' do
     let!(:default_stream) { organization.default_stream }
 

--- a/spec/routing/organizations_routing_spec.rb
+++ b/spec/routing/organizations_routing_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe OrganizationsController, type: :routing do
       expect(get: '/organizations').to route_to('organizations#index')
     end
 
+    it 'routes to #index as an xml sitemap' do
+      expect(get: '/organizations/resourcelist').to route_to('organizations#index', format: :xml)
+    end
+
+    it 'routes to #index as an format-specific xml sitemap' do
+      expect(get: '/organizations/normalized_resourcelist/marcxml').to route_to(
+        'organizations#index', normalized: true, flavor: 'marcxml', format: :xml
+      )
+    end
+
     it 'routes to #new' do
       expect(get: '/organizations/new').to route_to('organizations#new')
     end


### PR DESCRIPTION
![Screen Shot 2020-11-10 at 10 05 33](https://user-images.githubusercontent.com/111218/98713301-48200500-233c-11eb-8210-0e2c5da0de9b.png)

This provides the resourcesync capability lists of e.g.

http://127.0.0.1:3000/.well-known/resourcesync/normalized-capabilitylist/marcxml
and
http://127.0.0.1:3000/.well-known/resourcesync/normalized-capabilitylist/marc21

That link to organization-specific resourcelists for the normalized dumps + deltas.

Fixes #144 
Fixes #11  too, as long as we like resourcesync as an approach