### PR TITLE
Disable turbolinks when clicking the sign up page so there's not …

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -4,7 +4,7 @@
   <% end -%>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-    <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
+    <%= link_to t(".sign_up"), new_registration_path(resource_name), data: { turbolinks: false } %><br />
   <% end -%>
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>


### PR DESCRIPTION
…CSP/Turbolinks interference.

Closes #182 

Tried the strategy outlined in https://discuss.rubyonrails.org/t/turbolinks-broken-by-default-with-a-secure-csp/74790 but that didn't seem to make much difference.