### PR TITLE
Add a form for organizations to provide item-level mapping information

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -64,6 +64,10 @@ class OrganizationsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def organization_params
-    params.require(:organization).permit(:name, :slug, :icon, :code)
+    params.require(:organization)
+          .permit(
+            :name, :slug, :icon, :code,
+            normalization_steps: [[:destination_tag, :source_tag, { subfields: %i[i a m] }]]
+          )
   end
 end

--- a/app/models/marc_record.rb
+++ b/app/models/marc_record.rb
@@ -24,14 +24,9 @@ class MarcRecord < ApplicationRecord
   # rubocop:enable Metrics/AbcSize
 
   def augmented_marc
-    return marc if organization&.code.blank?
+    return marc unless organization
 
-    @augmented_marc ||= begin
-      duped_record = MARC::Record.new_from_hash(marc.to_hash)
-      duped_record.append(MARC::DataField.new('900', nil, nil, ['b', organization.code]))
-
-      duped_record
-    end
+    @augmented_marc ||= organization.augmented_marc_record_service.execute(marc)
   end
 
   private

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -26,4 +26,12 @@ class Organization < ApplicationRecord
   def latest_statistics
     statistics.latest.first_or_initialize
   end
+
+  def normalization_steps
+    super || {}
+  end
+
+  def augmented_marc_record_service
+    @augmented_marc_record_service ||= AugmentMarcRecordService.new(organization: self)
+  end
 end

--- a/app/services/augment_marc_record_service.rb
+++ b/app/services/augment_marc_record_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Service class for augmenting source MARC records with POD information
+class AugmentMarcRecordService
+  attr_reader :steps, :organization
+
+  DEFAULT_STEPS = %i[
+    append_pod_provenance_information
+    append_normalized_item_information
+  ].freeze
+
+  def initialize(steps: nil, organization: nil)
+    @steps = steps || DEFAULT_STEPS
+    @organization = organization || Organization.new
+  end
+
+  def execute(source_record)
+    steps.each_with_object(duped_record(source_record)) do |step, record|
+      send(step, record)
+    end
+  end
+
+  private
+
+  def append_pod_provenance_information(record)
+    return if organization.code.blank?
+
+    record.append(MARC::DataField.new('900', nil, nil, ['b', organization.code]))
+  end
+
+  def append_normalized_item_information(record)
+    return if organization.normalization_steps.blank?
+
+    organization.normalization_steps.each_value do |step|
+      map_normalized_item_field(record, step)
+    end
+  end
+
+  def map_normalized_item_field(record, step)
+    record.fields(step['source_tag']).each do |field|
+      subfield_data = step['subfields'].sort_by { |k, _v| k }.map do |destination_subfield, source_subfield|
+        [destination_subfield, field[source_subfield]] if source_subfield && field[source_subfield].present?
+      end.compact
+
+      record.append(MARC::DataField.new(step['destination_tag'], nil, nil, *subfield_data))
+    end
+  end
+
+  def duped_record(source_record)
+    MARC::Record.new_from_hash(source_record.to_hash)
+  end
+end

--- a/app/services/augment_marc_record_service.rb
+++ b/app/services/augment_marc_record_service.rb
@@ -14,6 +14,7 @@ class AugmentMarcRecordService
     @organization = organization || Organization.new
   end
 
+  # @param [MARC::Record] record to modify
   def execute(source_record)
     steps.each_with_object(duped_record(source_record)) do |step, record|
       send(step, record)
@@ -22,12 +23,18 @@ class AugmentMarcRecordService
 
   private
 
+  # Append a MARC 900$b containing the organization code of the organization that
+  # provided the record to POD.
+  # @param [MARC::Record] record to modify
   def append_pod_provenance_information(record)
     return if organization.code.blank?
 
-    record.append(MARC::DataField.new('900', nil, nil, ['b', organization.code]))
+    record.append(MARC::DataField.new('900', nil, nil, pod_source_metadata, ['b', organization.code]))
   end
 
+  # Perform organization-specific/specified normalization steps
+  # and add a $8 with a reference back to the source field (given as linking number = tag, sequence number = index)
+  # @param [MARC::Record] record to modify
   def append_normalized_item_information(record)
     return if organization.normalization_steps.blank?
 
@@ -37,16 +44,25 @@ class AugmentMarcRecordService
   end
 
   def map_normalized_item_field(record, step)
-    record.fields(step['source_tag']).each do |field|
-      subfield_data = step['subfields'].sort_by { |k, _v| k }.map do |destination_subfield, source_subfield|
-        [destination_subfield, field[source_subfield]] if source_subfield && field[source_subfield].present?
-      end.compact
+    record.fields(step['source_tag']).each.with_index do |field, index|
+      subfield_data = map_subfield_data(field, step['subfields'])
+      field_link = ['8', "#{field.tag}.#{index}\\p"]
 
-      record.append(MARC::DataField.new(step['destination_tag'], nil, nil, *subfield_data))
+      record.append(MARC::DataField.new(step['destination_tag'], nil, nil, pod_source_metadata, field_link, *subfield_data))
     end
+  end
+
+  def map_subfield_data(field, mapping)
+    mapping.sort_by { |k, _v| k }.map do |destination_subfield, source_subfield|
+      [destination_subfield, field[source_subfield]] if source_subfield && field[source_subfield].present?
+    end.compact
   end
 
   def duped_record(source_record)
     MARC::Record.new_from_hash(source_record.to_hash)
+  end
+
+  def pod_source_metadata
+    %w[5 POD]
   end
 end

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -14,6 +14,17 @@
     </label>
   </div>
 
+  <% if organization.persisted? %>
+    <hr />
+
+    <h3>Item information</h3>
+    <%= form.hidden_field 'normalization_steps[0][destination_tag]', maxlength: 3, value: organization.normalization_steps.values.dig(0, 'destination_tag') || 998 %>
+    <%= form.text_field 'normalization_steps[0][source_tag]', maxlength: 3, value: organization.normalization_steps.values.dig(0, 'source_tag'), label: 'What MARC field contains item-level information?' %>
+    <%= form.text_field 'normalization_steps[0][subfields][i]', maxlength: 1, value: organization.normalization_steps.values.dig(0, 'subfields', 'i'), label: 'Local identifier subfield' %>
+    <%= form.text_field 'normalization_steps[0][subfields][a]', maxlength: 1, value: organization.normalization_steps.values.dig(0, 'subfields', 'a'), label: 'Call number subfield' %>
+    <%= form.text_field 'normalization_steps[0][subfields][m]', maxlength: 1, value: organization.normalization_steps.values.dig(0, 'subfields', 'm'), label: 'Local library' %>
+  <% end %>
+
   <div class="actions">
     <%= form.primary %>
   </div>

--- a/db/migrate/20201113223126_add_normalization_steps_to_organizations.rb
+++ b/db/migrate/20201113223126_add_normalization_steps_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddNormalizationStepsToOrganizations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :organizations, :normalization_steps, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_222831) do
+ActiveRecord::Schema.define(version: 2020_11_13_223126) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 2020_11_12_222831) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "slug"
     t.string "code"
+    t.json "normalization_steps"
     t.index ["slug"], name: "index_organizations_on_slug", unique: true
   end
 

--- a/spec/models/marc_record_spec.rb
+++ b/spec/models/marc_record_spec.rb
@@ -47,8 +47,24 @@ RSpec.describe MarcRecord, type: :model do
   describe '#augmented_marc' do
     let(:attr) { { bytecount: 0, length: 1407 } }
 
+    before do
+      organization.update(normalization_steps: { '0' => {
+                            destination_tag: '998',
+                            source_tag: '999',
+                            subfields: { i: 'i', a: 'a', m: 'm' }
+                          } })
+    end
+
     it "applies the Organization's code as the 900$b" do
       expect(marc_record.augmented_marc.fields('900').first['b']).to eq 'COOlCOdE'
+    end
+
+    it 'applies the organization normalization steps' do
+      field = marc_record.augmented_marc.fields('998').first
+
+      expect(field.subfields.map(&:to_s)).to include('$a NA737.K4 A4 1980 ')
+        .and include('$i 36105032407764 ')
+        .and include('$m ART ')
     end
   end
 end

--- a/spec/models/marc_record_spec.rb
+++ b/spec/models/marc_record_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe MarcRecord, type: :model do
                           } })
     end
 
+    it 'adds a $5 to indicate a POD-added field' do
+      expect(marc_record.augmented_marc.fields('900').first['5']).to eq 'POD'
+    end
+
     it "applies the Organization's code as the 900$b" do
       expect(marc_record.augmented_marc.fields('900').first['b']).to eq 'COOlCOdE'
     end
@@ -65,6 +69,12 @@ RSpec.describe MarcRecord, type: :model do
       expect(field.subfields.map(&:to_s)).to include('$a NA737.K4 A4 1980 ')
         .and include('$i 36105032407764 ')
         .and include('$m ART ')
+    end
+
+    it 'includes provenance linking for derived data' do
+      field = marc_record.augmented_marc.fields('998').first
+
+      expect(field['8']).to eq '999.0\p'
     end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Organization do
-  describe 'jwt_token' do
-    let(:organization) { FactoryBot.create(:organization) }
+  let(:organization) { FactoryBot.create(:organization) }
 
+  describe '#jwt_token' do
     context 'when a jwt already exists' do
       before do
         AllowlistedJwt.create(resource: organization, jti: 'anything')
@@ -34,6 +34,12 @@ RSpec.describe Organization do
         token = JWT.decode(organization.jwt_token, Settings.jwt.secret, Settings.jwt.algorithm)
         expect(token[0]['jti']).to eq AllowlistedJwt.last.jti
       end
+    end
+  end
+
+  describe '#normalization_steps' do
+    it 'defaults to a hash' do
+      expect(organization.normalization_steps).to eq({})
     end
   end
 end

--- a/spec/views/organizations/edit.html.erb_spec.rb
+++ b/spec/views/organizations/edit.html.erb_spec.rb
@@ -23,4 +23,13 @@ RSpec.describe 'organizations/edit', type: :view do
       assert_select 'input[name=?]', 'organization[slug]'
     end
   end
+
+  it 'renders fields for normalization' do
+    render
+
+    assert_select 'form[action=?][method=?]', organization_path(organization), 'post' do
+      assert_select 'input[name=?]', 'organization[normalization_steps[0][destination_tag]]'
+      assert_select 'input[name=?]', 'organization[normalization_steps[0][subfields][i]]'
+    end
+  end
 end


### PR DESCRIPTION
Part of #162

![Screen Shot 2020-11-13 at 15 26 53](https://user-images.githubusercontent.com/111218/99130251-aa8b3680-25c4-11eb-9ebb-573856585e0d.png)

Augmented MARC records append the normalized fields (in this case, a set of 999s with the mapped subfields), plus some provenance information using the `$8` tag (🤷‍♂️) to connect the POD normalized form back to the original data field.