### PR TITLE
Pass the record count through to the MarcProfilingJob to avoid race conditions

### DIFF
--- a/app/analyzers/marc_analyzer.rb
+++ b/app/analyzers/marc_analyzer.rb
@@ -8,8 +8,8 @@ class MarcAnalyzer < ActiveStorage::Analyzer
   end
 
   def metadata
-    { analyzer: self.class.to_s, count: reader.count, type: reader.identify }.tap do
-      MarcProfilingJob.perform_later(blob)
+    { analyzer: self.class.to_s, count: count, type: reader.identify }.tap do
+      MarcProfilingJob.perform_later(blob, count: count)
     end
   rescue MARC::XMLParseError, MARC::Exception => e
     Rails.logger.info(e)
@@ -20,5 +20,9 @@ class MarcAnalyzer < ActiveStorage::Analyzer
 
   def reader
     @reader ||= MarcRecordService.new(blob)
+  end
+
+  def count
+    @count ||= reader.count
   end
 end

--- a/app/jobs/marc_profiling_job.rb
+++ b/app/jobs/marc_profiling_job.rb
@@ -32,10 +32,10 @@ class MarcProfilingJob < ApplicationJob
   #   - how many times a field/subfield is used in a record
   # and collect a sampling of field/subfield occurences.
   # rubocop:disable all (Ha!)
-  def perform(blob, sample_size: 25)
-    return unless blob.metadata['count']
+  def perform(blob, count: nil, sample_size: 25)
+    count ||= blob.metadata['count']
 
-    count = blob.metadata['count']
+    return unless count
 
     sampled_values = Hash.new { |hash, key| hash[key] = Sample.new(sample_size, count) }
     instance_frequency = Hash.new { |hash, key| hash[key] = 0 }


### PR DESCRIPTION
Otherwise, the `MarcProfilingJob` could run before the count metadata is actually available.