### PR TITLE
Add a public flag to organizations and use that to authorized access

### DIFF
--- a/app/controllers/proxy_controller.rb
+++ b/app/controllers/proxy_controller.rb
@@ -17,7 +17,7 @@ class ProxyController < ActiveStorage::BaseController
   # rubocop:disable Metrics/AbcSize
   def show
     attachment = ActiveStorage::Attachment.find(params[:id])
-    authorize!(:read, attachment.record.stream)
+    authorize!(:read, attachment)
 
     fresh_when(last_modified: attachment.blob.created_at, public: true, etag: attachment.blob.checksum)
     set_content_headers_from(attachment.blob)

--- a/db/migrate/20201119175843_add_public_to_organizations.rb
+++ b/db/migrate/20201119175843_add_public_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddPublicToOrganizations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :organizations, :public, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_17_154540) do
+ActiveRecord::Schema.define(version: 2020_11_19_175843) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2020_11_17_154540) do
     t.string "slug"
     t.string "code"
     t.json "normalization_steps"
+    t.boolean "public", default: true
     t.index ["slug"], name: "index_organizations_on_slug", unique: true
   end
 


### PR DESCRIPTION
And tweak #229 to use the flag to authorize access to attachments explicitly

This should also let us hide any of our test orgs from normal users