### PR TITLE
Couple of style tweaks

### DIFF
--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -18,6 +18,10 @@
 
 // Table of all organizations
 .organizations {
+  .icon-column {
+    min-width: 68px; // Try to avoid some layout shifting when icons are rendered
+  }
+
   .files-column {
     width: 6ch;
   }

--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -15,3 +15,10 @@
     margin-bottom: 0.25rem;
   }
 }
+
+// Table of all organizations
+.organizations {
+  .files-column {
+    width: 6ch;
+  }
+}

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -17,7 +17,7 @@
     <tbody>
       <% @organizations.each do |organization| %>
         <tr>
-          <td class="text-center">
+          <td class="text-center icon-column">
             <% if organization.icon.attached? %>
               <%= image_tag(organization.icon, class: 'icon-sm') %>
             <% end %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -5,7 +5,7 @@
     <thead>
       <tr>
         <th colspan="2">Name</th>
-        <th style="width: 6ch;" class="text-right">Files</th>
+        <th class="text-right files-column">Files</th>
         <th class="text-right">Size</th>
         <th class="text-right">Unique records</th>
         <th class="text-right">Total records</th>
@@ -25,7 +25,7 @@
           <td>
             <%= link_to organization.name, organization %>
           </td>
-          <td style="width: 6ch;" class="text-right"><%= organization.default_stream.files.size %></td>
+          <td class="text-right files-column"><%= organization.default_stream.files.size %></td>
           <td class="text-right"><%= number_to_human_size organization.default_stream.files.sum(:byte_size) %></td>
           <td class="text-right"><%= number_with_delimiter organization.latest_statistics.unique_record_count %></td>
           <td class="text-right"><%= number_with_delimiter organization.latest_statistics.record_count %></td>
@@ -37,7 +37,7 @@
       <tr class="table-info">
         <td></td>
         <td></td>
-        <td style="width: 6ch;" class="text-right"><%= number_with_delimiter(@organizations.sum {|org| org.default_stream.files.size }) %></td>
+        <td class="text-right files-column"><%= number_with_delimiter(@organizations.sum {|org| org.default_stream.files.size }) %></td>
         <td class="text-right"><%= number_to_human_size @organizations.sum {|org| org.default_stream.files.sum(:byte_size)} %></td>
         <td class="text-right"><%= number_with_delimiter(@organizations.sum { |org| org.latest_statistics.unique_record_count }) %></td>
         <td class="text-right"><%= number_with_delimiter(@organizations.sum { |org| org.latest_statistics.record_count })%></td>


### PR DESCRIPTION
1. Move inline styling to stylesheet (which wasn't actually working due to CSP)
2. Set a min-width on the org icon column so the table layout doesn't shift when icons render