### PR TITLE
Prefer resourceful abilities

### DIFF
--- a/app/controllers/allowlisted_jwts_controller.rb
+++ b/app/controllers/allowlisted_jwts_controller.rb
@@ -4,7 +4,6 @@
 class AllowlistedJwtsController < ApplicationController
   load_and_authorize_resource :organization
   load_and_authorize_resource through: :organization
-  authorize_resource class: :controller
 
   # GET /organizations/1/allowlisted_jwts
   # GET /organizations/1/allowlisted_jwts.json

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -59,7 +59,6 @@ class Ability
     can %i[crud profile info], [Stream, Upload], organization: { id: owned_orgs }
     can :read, MarcRecord, upload: { organization: { id: owned_orgs } }
     can :manage, AllowlistedJwt, resource_type: 'Organization', resource_id: owned_orgs
-    can :manage, :allowlisted_jwts_controller, resource_type: 'Organization', resource_id: owned_orgs
     can :read, ActiveStorage::Attachment, { record: { organization: { id: owned_orgs } } }
 
     member_orgs = Organization.with_role(:member, user).pluck(:id)


### PR DESCRIPTION
@ktamaral @marlo-longley In #665, I see you added this non-resourceful ability check, but I'm not sure  of its purpose when we already have the resource-oriented ability defined:

```
can :manage, AllowlistedJwt, resource_type: 'Organization', resource_id: owned_orgs
```

Can you clarify the purpose of the controller authorization, or make sure to add a test for it?