### PR TITLE
Guard against missing job status.

### DIFF
--- a/app/views/dashboard/_tab_uploads.html.erb
+++ b/app/views/dashboard/_tab_uploads.html.erb
@@ -51,7 +51,7 @@
           <!-- Did any uploads succeed in past 30 days? -->
           <td class="text-center">
             <% if provider.upload_in_last_30_days? %>
-              <%= bootstrap_icon(Settings.job_status_group[best_status(uploads)].icon_class, class: "pod-job-tracker-status #{best_status(uploads)}") %>
+              <%= bootstrap_icon(Settings.job_status_group[best_status(uploads)]&.icon_class, class: "pod-job-tracker-status #{best_status(uploads)}") %>
               <span class="visually-hidden"><%= best_status(uploads) %></span>
             <% else %>
               <p class="mb-0">No uploads in last 30 days</p>


### PR DESCRIPTION
In a new install, it's apparently possible to have new uploads that haven't been processed at all 🤷‍♂️ 