### PR TITLE
update table to have label elements for screen r

### DIFF
--- a/app/views/dashboard/summary.html.erb
+++ b/app/views/dashboard/summary.html.erb
@@ -70,7 +70,7 @@
       <tr>
         <td class="text-center">
           <i class="<%= Settings.metadata_status[file.pod_metadata_status].icon_class %> pod-metadata-status <%= file.pod_metadata_status %>"></i>
-          <span class="visually-hidden">Type of file: <%= file.pod_metadata_status %></span>
+          <span class="visually-hidden"><%= Settings.metadata_status[file.pod_metadata_status].label %></span>
         </td>
         <td>
           <%= link_to_if can?(:read, upload), upload.name, organization_upload_path(upload.organization, upload), title: t('.table.upload_title', name: upload.name) %>

--- a/app/views/uploads/_file_rows.html.erb
+++ b/app/views/uploads/_file_rows.html.erb
@@ -15,7 +15,7 @@
   <tr>
     <td class="align-middle text-center">
       <i class="<%= Settings.metadata_status[file.pod_metadata_status].icon_class %> pod-metadata-status <%= file.pod_metadata_status %>"></i>
-      <span class="visually-hidden">Type of file: <%= file.pod_metadata_status %></span>
+      <span class="visually-hidden"><%= Settings.metadata_status[file.pod_metadata_status].label %></span>
     </td> 
     <td class="align-middle">
       <%= link_to_if can?(:read, upload), file.filename, download_url(file), title: "Download #{file.filename}" %>


### PR DESCRIPTION
eaders

closes #854 

I know the ticket says it says we should prepend the status with type of file but I am pretty sure that is not accessibility friendly. I think the screen reader should tell the user which column they are in
<img width="1496" height="653" alt="Screenshot 2025-10-09 at 4 59 38 PM" src="https://github.com/user-attachments/assets/91103273-10ea-49f3-a6a2-e844f5c0a284" />
