### PR TITLE
Retry failed UpdateOrganizationStatisticsJob 1 time only

### DIFF
--- a/app/jobs/update_organization_statistics_job.rb
+++ b/app/jobs/update_organization_statistics_job.rb
@@ -3,6 +3,7 @@
 # Calculate some daily statistics for an organization
 class UpdateOrganizationStatisticsJob < ApplicationJob
   queue_as :default
+  sidekiq_options retry: 1
 
   def self.perform_all
     Organization.find_each { |o| perform_later(o) }


### PR DESCRIPTION
Since we run these on a schedule each day there's no point to keep retrying failed jobs. We'll just catch up the next day.

Related to #1188 