### PR TITLE
split full and delta dumps, paginate deltas

### DIFF
--- a/app/views/streams/_normalized_dump.html.erb
+++ b/app/views/streams/_normalized_dump.html.erb
@@ -1,4 +1,5 @@
 <% if normalized_dump %>
+  <h4>Full Dumps</h4>
   <table class="table table-striped mb-0">
     <thead>
       <th>Type</th>
@@ -10,12 +11,28 @@
     <tbody>
       <%= render partial: 'streams/dump_attachment', locals: { type: 'Full', attachment: normalized_dump.marc21.attachment, stream: normalized_dump.stream } %>
       <%= render partial: 'streams/dump_attachment', locals: { type: 'Full', attachment: normalized_dump.marcxml.attachment, stream: normalized_dump.stream } %>
-
-      <% normalized_dump.deltas.sort_by(&:created_at).each do |delta| %>
-        <%= render partial: 'streams/dump_attachment', locals: { type: 'Delta', attachment: delta.marc21.attachment, stream: normalized_dump.stream } %>
-        <%= render partial: 'streams/dump_attachment', locals: { type: 'Delta', attachment: delta.marcxml.attachment, stream: normalized_dump.stream } %>
-        <%= render partial: 'streams/dump_attachment', locals: { type: 'Deletes', attachment: delta.deletes.attachment, stream: normalized_dump.stream } %>
-      <% end %>
     </tbody>
   </table>
+
+  <% if normalized_dump.deltas.exists? %>
+    <h4 class="mt-4">Deltas and Deletes</h4>
+    <table class="table table-striped">
+      <thead>
+        <th>Type</th>
+        <th class="pl-4">File</th>
+        <th>Date created</th>
+        <th>Size</th>
+        <th class="text-end pr-4">Records</th>
+      </thead>
+      <tbody>
+        <% paginated_dump =  normalized_dump.deltas.order(created_at: :desc).page(params[:page]).per(5) %>
+        <% paginated_dump.each do |delta| %>
+          <%= render partial: 'streams/dump_attachment', locals: { type: 'Delta', attachment: delta.marc21.attachment, stream: normalized_dump.stream } %>
+          <%= render partial: 'streams/dump_attachment', locals: { type: 'Delta', attachment: delta.marcxml.attachment, stream: normalized_dump.stream } %>
+          <%= render partial: 'streams/dump_attachment', locals: { type: 'Deletes', attachment: delta.deletes.attachment, stream: normalized_dump.stream } %>
+        <% end %>
+      </tbody>
+    </table>
+    <%= paginate paginated_dump %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
I used per(4) because each delta has 3 entries so that gives 15 per page which seems like a good number. Screenshots are when I set per to 1 so I didn't have to create so much data.

closes #965 

<img width="1086" height="838" alt="Screenshot 2025-10-10 at 1 56 03 PM" src="https://github.com/user-attachments/assets/a9e9b223-f5a6-445e-86e8-f927ed56b033" />
<img width="1072" height="810" alt="Screenshot 2025-10-10 at 1 55 54 PM" src="https://github.com/user-attachments/assets/bdfb5d57-9d24-4bfe-8225-3d479ab039b9" />
