### PR TITLE
update local_time gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ group :deployment do
 end
 gem 'concurrent-ruby'
 
-gem "local_time", "~> 2.1"
+gem "local_time", "~> 3.0"
 
 gem "importmap-rails", "~> 1.1"
 gem 'propshaft'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
     llhttp-ffi (0.5.1)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    local_time (2.1.0)
+    local_time (3.0.3)
     logger (1.7.0)
     loofah (2.24.1)
       crass (~> 1.0.2)
@@ -567,7 +567,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   jwt
   kaminari
-  local_time (~> 2.1)
+  local_time (~> 3.0)
   marc
   okcomputer
   paper_trail


### PR DESCRIPTION
closes #859 

The screen reader was repeating the date because the time element had an aria-label. The updated version of the gem removed aria-label for accessibilty. 
https://github.com/basecamp/local_time/blob/e3ca9fd7e87d076fe74bd9e6b7f7a88298964ca9/CHANGELOG.md?plain=1#L26C2-L26C51 