### PR TITLE
move icon visually hidden spans to aria-label

### DIFF
--- a/app/views/dashboard/_tab_uploads.html.erb
+++ b/app/views/dashboard/_tab_uploads.html.erb
@@ -30,10 +30,10 @@
           <!-- Most recent upload status: -->
           <td class="text-center">
             <% if uploads %>
-              <i class="pod-job-tracker-status <%= Settings.job_status_group[files_status(uploads[0])].icon_class %> <%= files_status(uploads[0]) %>"></i>
-              <span class="visually-hidden"><%= files_status(uploads[0]) %></span>
+              <% status = files_status(uploads[0]) %>
+              <i class="pod-job-tracker-status <%= Settings.job_status_group[status].icon_class %> <%= status %>" aria-label="<%= status %>"></i>
             <% else %>
-              <i class="bi bi-exclamation-triangle-fill text-warning"></i>
+              <i class="bi bi-exclamation-triangle-fill text-warning" aria-label="missing upload"></i>
             <% end %>
           </td>
           <!-- Date of successful upload: -->
@@ -51,8 +51,8 @@
           <!-- Did any uploads succeed in past 30 days? -->
           <td class="text-center">
             <% if provider.upload_in_last_30_days? %>
-              <i class="pod-job-tracker-status <%= Settings.job_status_group[best_status(uploads)]&.icon_class %> <%= best_status(uploads) %>"></i>
-              <span class="visually-hidden"><%= best_status(uploads) %></span>
+              <% status = best_status(uploads) %>
+              <i class="pod-job-tracker-status <%= Settings.job_status_group[status]&.icon_class %> <%= status %>" aria-label="<%= status %>"></i>
             <% else %>
               <p class="mb-0">No uploads in last 30 days</p>
             <% end %>

--- a/app/views/dashboard/summary.html.erb
+++ b/app/views/dashboard/summary.html.erb
@@ -69,8 +69,8 @@
       <% upload.files.each do |file| %>
       <tr>
         <td class="text-center">
-          <i class="<%= Settings.metadata_status[file.pod_metadata_status].icon_class %> pod-metadata-status <%= file.pod_metadata_status %>"></i>
-          <span class="visually-hidden"><%= Settings.metadata_status[file.pod_metadata_status].label %></span>
+          <% status = file.pod_metadata_status %>
+          <i class="<%= Settings.metadata_status[status].icon_class %> pod-metadata-status <%= status %>" aria-label="<%= Settings.metadata_status[file.pod_metadata_status].label %>"></i>
         </td>
         <td>
           <%= link_to_if can?(:read, upload), upload.name, organization_upload_path(upload.organization, upload), title: t('.table.upload_title', name: upload.name) %>

--- a/app/views/uploads/_file_rows.html.erb
+++ b/app/views/uploads/_file_rows.html.erb
@@ -14,8 +14,8 @@
 <% upload.files.each do |file| %>
   <tr>
     <td class="align-middle text-center">
-      <i class="<%= Settings.metadata_status[file.pod_metadata_status].icon_class %> pod-metadata-status <%= file.pod_metadata_status %>"></i>
-      <span class="visually-hidden"><%= Settings.metadata_status[file.pod_metadata_status].label %></span>
+      <% status = file.pod_metadata_status %>
+      <i class="<%= Settings.metadata_status[status].icon_class %> pod-metadata-status <%= status %>" aria-label="<%= Settings.metadata_status[status].label  %>"></i>
     </td> 
     <td class="align-middle">
       <%= link_to_if can?(:read, upload), file.filename, download_url(file), title: "Download #{file.filename}" %>
@@ -27,8 +27,7 @@
     <td class="align-middle text-center">
       <% if can? :read, upload %>
         <%= link_to file_info_organization_upload_path(@organization, upload, file), class: 'btn btn-sm btn-secondary' do %>
-          <i class="bi bi-search pod-icon"></i>
-          <span class="visually-hidden">Profile</span>
+          <i class="bi bi-search pod-icon" aria-label="Profile"></i>
         <% end %>
         <% if upload.url.present? %>
           <%= link_to 'Source 🔗', upload.url, title: upload.url, class: 'btn btn-sm btn-link' %>


### PR DESCRIPTION
When using the screenreader the span tag is created as a separate element and not associated with the correct column. This fixes that and also gets rid of the fact the icon is read wrong by screen readers.