### PR TITLE
Do not save status check visits

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -4,6 +4,11 @@ OkComputer.mount_at = 'status'
 
 OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV.fetch('SIDEKIQ_REDIS_URL') { 'redis://localhost:6379/0' })
 
+# Do not track ahoy visits to status check page
+Rails.application.config.to_prepare do
+  OkComputer::OkComputerController.skip_before_action :track_ahoy_visit
+end
+
 # check activestorage by uploading + downloading a file
 class ActiveStorageCheck < OkComputer::Check
   def check


### PR DESCRIPTION
Part of #1173

We don't need to track visits to the status check page.