### PR TITLE
Add rake task to prune old ahoy visits without events

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -33,3 +33,7 @@ end
 every :day do
   runner 'UpdateOrganizationStatisticsJob.perform_all'
 end
+
+every :day, at: '3:00 am' do
+  rake 'agg:prune_ahoy_visits[180]'
+end

--- a/lib/tasks/admin_tasks.rake
+++ b/lib/tasks/admin_tasks.rake
@@ -40,6 +40,15 @@ namespace :agg do
     password
   end
 
+  desc 'Prune old ahoy visits data'
+  task :prune_ahoy_visits, %i[days_old] => :environment do |_, args|
+    started_at = Ahoy::Visit.arel_table[:started_at]
+    Ahoy::Visit.where(started_at.lt(args[:days_old].to_i.days.ago)).where.missing(:events).in_batches do |visits|
+      visits.delete_all
+      sleep(5) # Throttle the delete queries
+    end
+  end
+
   desc 'Seed data from Aggregator API'
   task seed_from_api: :environment do
     puts "Seeding data from Aggregator @ #{Settings.marc_fixture_seeds.host} (this may take a several minutes)"


### PR DESCRIPTION
Adds a rake task and daily cron to remove any visits older than 180 days that don't have associated events. I think we mostly care about visits with events so we'll keep those.

Fixes #1173 