### PR TITLE
update sidekiq_status to look in queue/workers

### DIFF
--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -47,8 +47,8 @@ class Stream < ApplicationRecord
 
   def job_tracker_status_groups
     {
-      needs_attention: job_trackers.order(created_at: :desc).select { |jt| jt.in_retry_set? || jt.in_dead_set? },
-      active: job_trackers.order(created_at: :desc).select { |jt| !jt.in_retry_set? && !jt.in_dead_set? }
+      needs_attention: job_trackers.order(created_at: :desc).select(&:error_processing?),
+      active: job_trackers.order(created_at: :desc).select { |jt| jt.sidekiq_status == 'active' }
     }
   end
 

--- a/spec/features/homepage_summary_spec.rb
+++ b/spec/features/homepage_summary_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe 'homepage summary' do
 
     # run the statistics jobs so stats are available
     UpdateOrganizationStatisticsJob.perform_now(provider)
-    ExtractMarcRecordMetadataJob.perform_later(upload1)
-    ExtractMarcRecordMetadataJob.perform_later(upload2)
     visit '/'
   end
 
@@ -53,8 +51,8 @@ RSpec.describe 'homepage summary' do
       expect(page).to have_content '9953670.marc'
     end
 
-    it 'displays the processing status of any active jobs' do
-      expect(page).to have_content '2 jobs active'
+    it 'displays the processing status' do
+      expect(page).to have_content 'No active jobs'
     end
 
     it 'displays the Provider home link' do

--- a/spec/models/job_tracker_spec.rb
+++ b/spec/models/job_tracker_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe JobTracker do
     allow(ActiveJob::Status).to receive(:get).with(job_id).and_return(status_attributes)
     allow(Sidekiq::RetrySet).to receive(:new).and_return(retry_set)
     allow(Sidekiq::DeadSet).to receive(:new).and_return(dead_set)
+    allow(Sidekiq::Queue).to receive(:new).and_return(job)
     allow(job).to receive(:size).and_return(1)
     allow(no_job).to receive(:size).and_return(1)
   end


### PR DESCRIPTION
closes #1177 

We deleted a bunch of jobs so this really only helps with 9 existing jobs. This just checks to see if the jobs we think are active actually are. We can sometimes have jobs that get deleted from sidekiq showing up even though they aren't active.