### PR TITLE
Remove marc_profiles foreign key from uploads

### DIFF
--- a/db/migrate/20251014124215_replace_marc_profile_foreign_key.rb
+++ b/db/migrate/20251014124215_replace_marc_profile_foreign_key.rb
@@ -1,0 +1,7 @@
+class ReplaceMarcProfileForeignKey < ActiveRecord::Migration[8.0]
+  def change
+    if foreign_key_exists?(:marc_profiles, :uploads)
+      remove_foreign_key :marc_profiles, :uploads
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_13_212130) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_14_124215) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -301,5 +301,4 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_13_212130) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "contact_emails", "organizations"
   add_foreign_key "default_stream_histories", "streams"
-  add_foreign_key "marc_profiles", "uploads"
 end


### PR DESCRIPTION
I think this is needed to fix https://app.honeybadger.io/projects/77305/faults/124290097

```
PG::ForeignKeyViolation: ERROR: update or delete on table "uploads" violates foreign key constraint "fk_rails_e6884e468c" on table "marc_profiles" DETAIL: Key (id)=(287675) is still referenced from table "marc_profiles". 
```