### PR TITLE
Display slug in stream info table

### DIFF
--- a/app/views/streams/index.html.erb
+++ b/app/views/streams/index.html.erb
@@ -10,6 +10,7 @@
     <thead>
       <tr>
         <th>Name</th>
+        <th>Slug</th>
         <th>Status</th>
         <th>Last updated</th>
         <th class="text-end">Files</th>
@@ -21,6 +22,7 @@
       <% @streams.active.sort_by(&:updated_at).reverse.each do |stream| %>
       <tr>
         <td><%= link_to stream.display_name, organization_stream_path(@organization, stream) %></td>
+        <td><%= stream.slug %></td>
         <td>
           <%= default_stream_status_badge(stream) if stream.default_stream_histories.any? %>
         </td>


### PR DESCRIPTION
Closes [#1016](https://github.com/pod4lib/aggregator/issues/1016) 

<img width="1348" height="427" alt="Screenshot 2025-10-14 at 1 50 13 PM" src="https://github.com/user-attachments/assets/cef6943c-eead-44cd-a391-2532c945ea39" />
