### PR TITLE
don't display empty list, switch badge to be static

### DIFF
--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -9,41 +9,37 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav me-auto">
-        <% if current_user %>
-        <li class="nav-item">
-          <%= link_to t('.providers'), organizations_url, class: class_names('nav-link', { active: current_page?(organizations_url) }) %>
-        </li>
-        <% end %>
-        <% if can? :read, :pages_data %>
-        <li class="nav-item">
-          <%= link_to t('.data'), data_url, class: class_names('nav-link', { active: current_page?(data_url) }), data: { turbo: false } %>
-        </li>
-        <% end %>
-        <% if can? :manage, :dashboard_controller %>
-        <li class="nav-item">
-          <%= link_to t('.activity'), activity_url, class: class_names('nav-link', { active: current_page?(activity_url) }), data: { turbo: false } %>
-        </li>
-        <% end %>
-        <% if can? :manage, User %>
-        <li class="nav-item">
-          <%= link_to t('.users'), site_users_url, class: class_names('nav-link', { active: current_page?(site_users_url) }) %>
-        </li>
-        <% end %>
-      </ul>
-
-      <% if current_user && current_user.has_role?(:admin) %>
-        <span class="badge bg-warning text-dark h-100 my-auto d-none d-md-block"><%= t('.is_admin') %></span>
+      <%if current_user %>
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <%= link_to t('.providers'), organizations_url, class: class_names('nav-link', { active: current_page?(organizations_url) }) %>
+          </li>
+          <% if can? :read, :pages_data %>
+          <li class="nav-item">
+            <%= link_to t('.data'), data_url, class: class_names('nav-link', { active: current_page?(data_url) }), data: { turbo: false } %>
+          </li>
+          <% end %>
+          <% if can? :manage, :dashboard_controller %>
+          <li class="nav-item">
+            <%= link_to t('.activity'), activity_url, class: class_names('nav-link', { active: current_page?(activity_url) }), data: { turbo: false } %>
+          </li>
+          <% end %>
+          <% if can? :manage, User %>
+          <li class="nav-item">
+            <%= link_to t('.users'), site_users_url, class: class_names('nav-link', { active: current_page?(site_users_url) }) %>
+          </li>
+          <% end %>
+        </ul>
       <% end %>
 
-      <ul class="navbar-nav">
+      <ul class="navbar-nav justify-content-end flex-grow-1">
         <% if current_user %>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
               aria-expanded="false">
               <%= current_user.email %>
               <% if current_user.has_role? :admin %>
-                <span class="badge bg-warning text-dark h-100 my-auto d-inline-block d-md-none"><%= t('.is_admin') %></span>
+                <span class="badge bg-warning text-dark h-100 my-auto ms-1"><%= t('.is_admin') %></span>
               <% end %>
             </a>
             <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">


### PR DESCRIPTION
closes [#1256](https://github.com/pod4lib/aggregator/issues/1256)
I moved where the badge is to just to the right of the username. I don't know why it was in two places to begin with but for accessibility reasons it makes sense not to switch positions based on screen size.

Before:
<img width="1054" height="550" alt="Screenshot 2025-10-15 at 3 13 48 PM" src="https://github.com/user-attachments/assets/cac3060e-6cd8-430c-8d4f-d9b110b7684f" />

After:
<img width="1072" height="376" alt="Screenshot 2025-10-15 at 3 14 07 PM" src="https://github.com/user-attachments/assets/001282b0-e642-4208-a504-01dd59d626d0" />

Before:
<img width="1061" height="128" alt="Screenshot 2025-10-15 at 3 28 12 PM" src="https://github.com/user-attachments/assets/c60bd1c4-1a0c-49e4-89e8-8784d1afbe1b" />

After:
<img width="1188" height="60" alt="Screenshot 2025-10-15 at 3 23 54 PM" src="https://github.com/user-attachments/assets/ecf35879-dddc-44d1-b39c-4846a9173fcf" />

Before:
<img width="757" height="296" alt="Screenshot 2025-10-15 at 3 28 04 PM" src="https://github.com/user-attachments/assets/feea16f5-1755-4b05-8259-4ce06bb56c1e" />

After:
<img width="757" height="254" alt="Screenshot 2025-10-15 at 3 24 01 PM" src="https://github.com/user-attachments/assets/9b8e61f7-170d-4322-9682-43c7cdc8f8c2" />


Changes without whitespace

<img width="1655" height="807" alt="Screenshot 2025-10-15 at 3 39 22 PM" src="https://github.com/user-attachments/assets/b72e6903-e8b2-4109-9917-85f1a94b4750" />

