### PR TITLE
accessibility fixes for footer

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.css
+++ b/app/assets/stylesheets/bootstrap-overrides.css
@@ -3,12 +3,21 @@
   --bs-popover-max-width: 600px;
 }
 
-footer.bg-light a {
-  color: var(--text-muted-bg-light);
+footer.bg-light {
+  a {
+    --bs-link-color-rgb: 67, 66, 62;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  p a {
+    text-decoration: underline;
+  }
 }
 
 .bg-light a {
-  color: var(--link-bg-light);
+  --bs-link-color-rgb: 0, 106, 248;
 }
 
 .alert-info code {

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -3,8 +3,6 @@
   --pod-med-dark: #194687;
   --pod-med: #1375BC;
 
-  --text-muted-bg-light: #6a737b;
-  --link-bg-light: #006af8;
   --code-bg-info: #c82279;
   --tooltip-max-width: 600px;
 }

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -13,13 +13,13 @@
         <h3 class="h5"><%= t('.docs.heading') %></h3>
         <ul class="list-unstyled mb-1">
           <li>
-            <%= link_to t('.docs.api'), 'https://github.com/pod4lib/aggregator/wiki/Uploading-data-using-the-API', class: 'text-decoration-none' %>
+            <%= link_to t('.docs.api'), 'https://github.com/pod4lib/aggregator/wiki/Uploading-data-using-the-API' %>
           </li>
           <li>
-            <%= link_to t('.docs.data'), 'https://github.com/pod4lib/aggregator/wiki/Data-requirements', class: 'text-decoration-none' %>
+            <%= link_to t('.docs.data'), 'https://github.com/pod4lib/aggregator/wiki/Data-requirements' %>
           </li>
           <li>
-            <%= link_to t('.docs.retention_policy'), 'https://github.com/pod4lib/aggregator/wiki/Retention-policy', class: 'text-decoration-none' %>
+            <%= link_to t('.docs.retention_policy'), 'https://github.com/pod4lib/aggregator/wiki/Retention-policy' %>
           </li>
         </ul>
       </div>
@@ -27,13 +27,13 @@
         <h3 class="h5"><%= t('.resources.heading') %></h3>
         <ul class="list-unstyled mb-1">
           <li>
-            <%= link_to t('.resources.contributing'), 'https://github.com/pod4lib/aggregator/wiki#getting-help', class: 'text-decoration-none' %>
+            <%= link_to t('.resources.contributing'), 'https://github.com/pod4lib/aggregator/wiki#getting-help' %>
           </li>
           <li>
-            <%= link_to t('.resources.framework'), 'https://docs.google.com/document/d/1EZG7z_A13jxPfHbYhT7Ae4Ays10fhecqfoGJhqrcjD8/edit', class: 'text-decoration-none' %>
+            <%= link_to t('.resources.framework'), 'https://docs.google.com/document/d/1EZG7z_A13jxPfHbYhT7Ae4Ays10fhecqfoGJhqrcjD8/edit' %>
           </li>
           <li>
-            <%= link_to t('.resources.github'), 'https://github.com/pod4lib/aggregator', class: 'text-decoration-none' %>
+            <%= link_to t('.resources.github'), 'https://github.com/pod4lib/aggregator' %>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
closes #1248 

Before:
<img width="1340" height="202" alt="Screenshot 2025-10-15 at 4 19 29 PM" src="https://github.com/user-attachments/assets/b5dbf36f-5c98-4e68-9aef-182ac4478842" />

After:

<img width="1291" height="207" alt="Screenshot 2025-10-15 at 4 19 55 PM" src="https://github.com/user-attachments/assets/7510968b-6552-4975-bfdf-8c2e43967524" />

The removal of the text-underline-none on the individual menu items allows for underline on hover which is wanted for accessible websites to indicate to the user the items which items the footer are links without just color.
