### PR TITLE
Run normalized dumps on the stream, not the organization.

### DIFF
--- a/spec/features/normalized_download_spec.rb
+++ b/spec/features/normalized_download_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Downloading normalized files from POD' do
   describe 'Full dumps' do
     before do
       allow(Time.zone).to receive(:today).and_return('2020-01-01')
-      GenerateFullDumpJob.perform_now(organization)
+      GenerateFullDumpJob.perform_now(organization.default_stream)
     end
 
     it 'generates binary & xml full dump files and provides a link to them' do

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'OAI-PMH' do
       create(:upload, :binary_marc, stream: organization.default_stream)
     end
     travel_to Time.zone.local(2020, 5, 6).end_of_day do
-      GenerateFullDumpJob.perform_now(organization)
+      GenerateFullDumpJob.perform_now(organization.default_stream)
     end
 
     # delta dump from the next day, add one and delete one record
@@ -29,7 +29,7 @@ RSpec.describe 'OAI-PMH' do
       create(:upload, :deleted_marc_xml, stream: organization.default_stream)
     end
     travel_to Time.zone.local(2020, 5, 7).end_of_day do
-      GenerateDeltaDumpJob.perform_now(organization)
+      GenerateDeltaDumpJob.perform_now(organization.default_stream)
     end
 
     # required for API access

--- a/spec/jobs/compact_uploads_job_spec.rb
+++ b/spec/jobs/compact_uploads_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CompactUploadsJob do
 
     Timecop.return
 
-    GenerateFullDumpJob.perform_now(organization)
+    GenerateFullDumpJob.perform_now(organization.default_stream)
   end
 
   it 'compacts old uploads into a single upload' do # rubocop:disable RSpec/ExampleLength

--- a/spec/models/normalized_dump_spec.rb
+++ b/spec/models/normalized_dump_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NormalizedDump do
 
   before do
     upload.files.blobs.first.analyze
-    GenerateFullDumpJob.perform_now(organization)
+    GenerateFullDumpJob.perform_now(organization.default_stream)
     # Manually set the count metadata
     organization.default_stream.reload.current_full_dump.marc21.attachment.metadata = { 'count' => 1 }
   end


### PR DESCRIPTION
It's a little more flexible if we can generate dumps on the stream itself 🤷‍♂️ 