### PR TITLE
Add Settings.marc_record_writer_tmpdir to control the base directory …

### DIFF
--- a/app/services/marc_record_writer_service.rb
+++ b/app/services/marc_record_writer_service.rb
@@ -36,6 +36,8 @@ class MarcRecordWriterService
 
   def unlink
     @opened_files.each(&:unlink)
+
+    FileUtils.rm_rf tempdir
   end
 
   private
@@ -73,7 +75,7 @@ class MarcRecordWriterService
   end
 
   def temp_file(name)
-    Tempfile.new("#{base_name}-#{name}", binmode: true).tap do |file|
+    Tempfile.new("#{base_name}-#{name}", tempdir, binmode: true).tap do |file|
       @opened_files << file
     end
   end
@@ -95,5 +97,9 @@ class MarcRecordWriterService
         field.subfields.any? { |sf| sf.value.include?("\uFFFD") }
       end
     end
+  end
+
+  def tempdir
+    @tempdir ||= Dir.mktmpdir(base_name || 'marc_record_writer', Settings.marc_record_writer_tmpdir || Dir.tmpdir)
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,3 +58,5 @@ oai_max_page_size: 5000
 
 # base ID of the repository used to generate OAI IDs for records
 oai_repository_id: 'pod.stanford.edu'
+
+marc_record_writer_tmpdir: ~


### PR DESCRIPTION
…for the writer temporary files.

For whatever reason, pod-prod has a large `/tmp` dir, but on the worker boxes it is pretty small (but the app directory is large) 🤷‍♂️  