### PR TITLE
Add Group model for grouping organizations

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Controller for managing organization groups
+class GroupsController < ApplicationController
+  load_and_authorize_resource
+
+  def index
+    @groups = Group.all
+    @organizations = Organization.all
+  end
+
+  # POST /group
+  # POST /group.json
+  def create
+    @group = Group.new(group_params)
+
+    respond_to do |format|
+      if @group.save
+        format.html { redirect_to @group, notice: t('.success'), status: :see_other }
+        format.json { render :show, status: :created, location: @group }
+      else
+        format.html { render :new }
+        format.json { render json: @group.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /group/1
+  # PATCH/PUT /group/1.json
+  def update
+    respond_to do |format|
+      if @group.update(group_params)
+        format.html { redirect_to @group, notice: t('.success') }
+        format.json { render :show, status: :ok, location: @group }
+      else
+        format.html { redirect_back_or_to @group, alert: t('.error') }
+        format.json { render json: @group.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /group/1
+  # DELETE /group/1.json
+  def destroy
+    @group.destroy
+    respond_to do |format|
+      format.html { redirect_to groups_url, notice: t('.success'), status: :see_other }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  # Only allow a list of trusted parameters through.
+  def group_params
+    params.expect(group: [:name, :short_name, :slug, :description, :icon, { organization_ids: [] }])
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Group of organizations
+class Group < ApplicationRecord
+  extend FriendlyId
+
+  friendly_id :name, use: %i[finders slugged]
+
+  has_paper_trail
+
+  has_many :group_memberships, dependent: :destroy
+  has_many :organizations, through: :group_memberships
+  has_one_attached :icon
+
+  default_scope { order(name: :asc) }
+
+  def display_name
+    short_name.presence || name
+  end
+end

--- a/app/models/group_membership.rb
+++ b/app/models/group_membership.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Connects organizations to groups (many-to-many)
+class GroupMembership < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :organization
+  belongs_to :group
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -13,6 +13,8 @@ class Organization < ApplicationRecord
   has_many :uploads, through: :streams
   has_many :marc_records, through: :streams, inverse_of: :organization
   has_many :allowlisted_jwts, as: :resource, dependent: :delete_all
+  has_many :group_memberships, dependent: :destroy
+  has_many :groups, through: :group_memberships
   has_one :contact_email, dependent: :delete
   has_one_attached :icon
   has_many :statistics, dependent: :delete_all, as: :resource

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,0 +1,14 @@
+<%= form.text_field :name %>
+<%= form.text_field :short_name %>
+<%= form.text_field :slug %>
+<%= form.text_area :description, rows: 3 %><div class="mb-3">
+  <label class="form-label" for="customFile">
+    <% if group.icon.attached? %>
+    Replace icon file
+    <% else %>
+    Choose icon file
+    <% end %>
+  </label>
+  <%= form.file_field_without_bootstrap :icon, type: :file, direct_upload: true, id: 'customFile', class: 'form-control', accept: '.svg, .jpg, .png' %>
+</div>
+<%= form.collection_check_boxes(:organization_ids, Organization.all, :id, :name, label: 'Member organizations') %>

--- a/app/views/groups/_group.json.jbuilder
+++ b/app/views/groups/_group.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+json.extract! group, :id, :name, :short_name, :slug, :description, :created_at, :updated_at
+json.url group_url(group, format: :json)
+json.organizations group.organizations do |organization|
+  json.extract! organization, :id, :name, :slug, :created_at, :updated_at
+  json.url organization_url(organization, format: :json)
+end

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="container mt-4">
+  <h1>Edit group</h1>
+  <%= bootstrap_form_with(model: @group, url: group_path(@group), html: { method: :put }) do |form| %>
+    <%= render 'form', group: @group, form: form %>
+    <div class="actions">
+      <%= form.primary 'Update group' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,0 +1,78 @@
+<div class="container mt-4">
+  <h1>Groups</h1>
+  <table class="table table-striped mt-4">
+    <thead>
+      <tr>
+        <th colspan="2">Name</th>
+        <th>Short name</th>
+        <th>Slug</th>
+        <th>Description</th>
+        <th colspan="2">Actions</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @groups.each do |group| %>
+        <% next unless can? :read, group %>
+        <tr>
+          <td class="align-middle text-center icon-column">
+            <% if group.icon.attached? %>
+              <%= image_tag(group.icon, alt: '', class: 'icon-sm') %>
+            <% end %>
+          </td>
+          <td class="align-middle"><%= link_to group.name, group %></td>
+          <td class="align-middle"><%= group.display_name %></td>
+          <td class="align-middle"><%= group.slug %></td>
+          <td class="align-middle"><%= group.description&.truncate(50) %></td>
+          <% if can? :manage, Group %>
+            <td class="align-middle"><%= link_to 'Edit', edit_group_path(group), class: 'btn btn-secondary btn-sm' if can? :edit, group %></td>
+            <td class="align-middle"><%= link_to 'Delete', group, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' if can? :destroy, group %></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if can? :manage, Group %>
+    <%= link_to 'New group', new_group_path, class: 'btn btn-primary' if can? :create, Group.new %>
+  <% end %>
+
+  <div class="mt-5">
+    <h2>Group membership</h2>
+    <table class="table table-striped mt-4" style="width: auto;">
+      <thead>
+        <tr>
+          <th colspan="2" class="pe-5">Organization</th>
+          <% @groups.each do |group| %>
+            <th class="pe-5"><%= group.display_name %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% @organizations.each do |organization| %>
+          <tr>
+            <td class="align-middle text-center icon-column">
+              <% if organization.icon.attached? %>
+                <%= image_tag(organization.icon, alt: '', class: 'icon-sm') %>
+              <% end %>
+            </td>
+            <td class="align-middle">
+              <%= link_to organization.name, organization %>
+            </td>
+            <% @groups.each do |group| %>
+              <td class="align-middle">
+                <% if group.organizations.include?(organization) %>
+                  <i class="bi bi-check-circle-fill text-success"></i>
+                  <span class="visually-hidden">Member</span>
+                <% else %>
+                  <i class="bi bi-dash-circle"></i>
+                  <span class="visually-hidden">Not a member</span>
+                <% end %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/groups/index.json.jbuilder
+++ b/app/views/groups/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @groups, partial: 'groups/group', as: :group

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,0 +1,9 @@
+<div class="container mt-4">
+  <h1>New group</h1>
+  <%= bootstrap_form_with(model: @group, local: true) do |form| %>
+    <%= render 'form', group: @group, form: form %>
+    <div class="actions">
+      <%= form.primary 'Create group' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,0 +1,32 @@
+<div class="container mt-4">
+  <h1><%= @group.name %></h1>
+  <dl>
+    <dt>Icon</dt>
+    <dd>
+      <% if @group.icon.attached? %>
+        <%= image_tag(@group.icon, alt: '', class: 'icon-sm') %>
+      <% else %>
+        No icon
+      <% end %>
+    </dd>
+    <dt>Short name</dt>
+    <dd><%= @group.short_name %></dd>
+    <dt>Slug</dt>
+    <dd><%= @group.slug %></dd>
+    <dt>Description</dt>
+    <dd><%= @group.description %></dd>
+    <dt>Member organizations</dt>
+    <dd>
+      <% if @group.organizations.any? %>
+        <ul>
+          <% @group.organizations.each do |organization| %>
+            <li><%= link_to organization.name, organization %></li>
+          <% end %>
+        </ul>
+      <% else %>
+        No member organizations
+      <% end %>
+    </dd>
+  </dl>
+  <%= link_to 'Edit', edit_group_path(@group), class: 'btn btn-primary' if can? :edit, @group %>
+</div>

--- a/app/views/groups/show.json.jbuilder
+++ b/app/views/groups/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'groups/group', group: @group

--- a/app/views/organizations/_organization.json.jbuilder
+++ b/app/views/organizations/_organization.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.extract! organization, :id, :name, :slug, :created_at, :updated_at
+json.extract! organization, :id, :name, :slug, :groups, :created_at, :updated_at
 json.url organization_url(organization, format: :json)
 json.streams organization.streams do |stream|
   json.id stream.id

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -29,6 +29,11 @@
             <%= link_to t('.users'), site_users_url, class: class_names('nav-link', { active: current_page?(site_users_url) }) %>
           </li>
           <% end %>
+          <% if can? :manage, Group %>
+            <li class="nav-item">
+              <%= link_to t('.groups'), groups_url, class: class_names('nav-link', { active: current_page?(groups_url) }) %>
+            </li>
+          <% end %>
         </ul>
       <% end %>
 

--- a/app/views/shared/_organization_header.html.erb
+++ b/app/views/shared/_organization_header.html.erb
@@ -9,6 +9,18 @@
         <%= @organization.name %>
       </h1>
       <div class="d-flex flex-column ms-5">
+        <% if @organization.groups.any? %>
+          <span class="lead">
+            <% @organization.groups.each do |group| %>
+              <span class="me-2">
+                <% if group.icon.attached? %>
+                  <%= image_tag(group.icon, alt: '', class: '', height: 25) %>
+                <% end %>
+                <%= group.display_name %>
+              </span>
+            <% end %>
+          </span>
+        <% end %>
         <% if @organization.provider? && @organization.code.present? %>
           <span class="lead"><%= t('.marc_code', code: @organization.code) %></span>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,14 @@ en:
         upload_title: View upload %{name}
       title: Recent activity
       upload_title: Upload activity
+  groups:
+    create:
+      success: Group was successfully created.
+    destroy:
+      success: Group was successfully destroyed.
+    update:
+      error: Group could not be updated.
+      success: Group was successfully updated.
   job_tracker:
     status_group:
       active:
@@ -155,6 +163,7 @@ en:
       brand: Aggregator
       data: Data
       edit_profile: Edit profile
+      groups: Groups
       is_admin: POD Admin
       login: Login
       logout: Logout

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
     route_for(:proxy_download, attachment.id, attachment.filename, options)
   end
 
+  resources :groups
   resources :site_users, only: [:index, :update]
 
   authenticate :user, lambda { |u| u.has_role? :admin } do

--- a/db/migrate/20251016131702_create_groups.rb
+++ b/db/migrate/20251016131702_create_groups.rb
@@ -1,0 +1,13 @@
+class CreateGroups < ActiveRecord::Migration[8.0]
+  def change
+    create_table :groups do |t|
+      t.string :name
+      t.string :short_name
+      t.string :slug
+      t.text :description
+
+      t.timestamps
+    end
+    add_index :groups, :slug, unique: true
+  end
+end

--- a/db/migrate/20251016183821_create_group_memberships.rb
+++ b/db/migrate/20251016183821_create_group_memberships.rb
@@ -1,0 +1,10 @@
+class CreateGroupMemberships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :group_memberships do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.references :group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -152,6 +152,25 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_20_183942) do
     t.index ["stream_id"], name: "index_full_dumps_on_stream_id"
   end
 
+  create_table "group_memberships", force: :cascade do |t|
+    t.integer "organization_id", null: false
+    t.integer "group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_group_memberships_on_group_id"
+    t.index ["organization_id"], name: "index_group_memberships_on_organization_id"
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "name"
+    t.string "short_name"
+    t.string "slug"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_groups_on_slug", unique: true
+  end
+
   create_table "job_trackers", force: :cascade do |t|
     t.string "reports_on_type", null: false
     t.integer "reports_on_id", null: false
@@ -330,4 +349,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_20_183942) do
   add_foreign_key "default_stream_histories", "streams"
   add_foreign_key "delta_dumps", "normalized_dumps"
   add_foreign_key "full_dumps", "normalized_dumps"
+  add_foreign_key "group_memberships", "groups"
+  add_foreign_key "group_memberships", "organizations"
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :group do
+    sequence(:name) { |n| "A group of organizations #{n}" }
+    sequence(:short_name) { |n| "Group#{n}" }
+    sequence(:slug) { |n| "group-#{n}" }
+    factory :group_with_organizations do
+      after(:create) do |group|
+        group.organizations << create_list(:organization, 3)
+      end
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Group do
+  let(:group) { create(:group) }
+  let(:organization) { create(:organization) }
+
+  describe '#display_name' do
+    context 'when short_name is present' do
+      it 'returns the short_name' do
+        group.short_name = 'Short Name'
+        expect(group.display_name).to eq 'Short Name'
+      end
+    end
+
+    context 'when short_name is blank' do
+      it 'returns the name' do
+        group.short_name = ''
+        group.name = 'Full Name'
+        expect(group.display_name).to eq 'Full Name'
+      end
+    end
+  end
+end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Groups' do
+  before do
+    sign_in create(:admin)
+  end
+
+  let(:valid_attributes) do
+    { name: 'Test Group', short_name: 'Test', slug: 'test-group' }
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      Group.create! valid_attributes
+      get groups_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      group = Group.create! valid_attributes
+      get group_url(group)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_group_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      group = Group.create! valid_attributes
+      get edit_group_url(group)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    it 'creates a new Group' do
+      expect do
+        post groups_url, params: { group: valid_attributes }
+      end.to change(Group, :count).by(1)
+    end
+
+    it 'redirects to the created group' do
+      post groups_url, params: { group: valid_attributes }
+      expect(response).to redirect_to(group_url(Group.last))
+    end
+  end
+
+  describe 'PATCH /update' do
+    let(:group) { Group.create! valid_attributes }
+    let(:new_attributes) do
+      { name: 'Updated Group Name' }
+    end
+
+    it 'updates the requested group' do
+      patch group_url(group), params: { group: new_attributes }
+      group.reload
+      expect(group.name).to eq('Updated Group Name')
+    end
+
+    it 'redirects to the group' do
+      patch group_url(group), params: { group: new_attributes }
+      expect(response).to redirect_to(group_url(group))
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested group' do
+      group = Group.create! valid_attributes
+      expect do
+        delete group_url(group)
+      end.to change(Group, :count).by(-1)
+    end
+
+    it 'redirects to the groups list' do
+      group = Group.create! valid_attributes
+      delete group_url(group)
+      expect(response).to redirect_to(groups_url)
+    end
+  end
+end

--- a/spec/routing/groups_routing_spec.rb
+++ b/spec/routing/groups_routing_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'routes for OrganizationsController' do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/groups').to route_to('groups#index')
+    end
+
+    it 'routes to #show' do
+      expect(get: '/groups/1').to route_to('groups#show', id: '1')
+    end
+
+    it 'routes to #new' do
+      expect(get: '/groups/new').to route_to('groups#new')
+    end
+
+    it 'routes to #edit' do
+      expect(get: '/groups/1/edit').to route_to('groups#edit', id: '1')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/groups').to route_to('groups#create')
+    end
+
+    it 'routes to #update via PUT' do
+      expect(put: '/groups/1').to route_to('groups#update', id: '1')
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(patch: '/groups/1').to route_to('groups#update', id: '1')
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/groups/1').to route_to('groups#destroy', id: '1')
+    end
+  end
+end

--- a/spec/views/groups/edit.html.erb_spec.rb
+++ b/spec/views/groups/edit.html.erb_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'groups/edit' do
+  let(:group) { create(:group) }
+
+  before do
+    assign(:group, group)
+    render
+  end
+
+  it 'renders edit group form' do
+    assert_select 'form[action=?][method=?]', group_path(group), 'post' do
+      assert_select 'input[name=?]', 'group[name]'
+      assert_select 'input[name=?]', 'group[short_name]'
+      assert_select 'input[name=?]', 'group[slug]'
+    end
+  end
+end

--- a/spec/views/groups/index.html.erb_spec.rb
+++ b/spec/views/groups/index.html.erb_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'groups/index' do
+  let(:org_one) { create(:organization, name: 'Organization One', provider: true) }
+  let(:org_two) { create(:organization, name: 'Organization Two', provider: true) }
+  let(:group_one) { create(:group, name: 'Group One', organizations: [org_one]) }
+  let(:group_two) { create(:group, name: 'Group Two') }
+
+  before do
+    assign(:groups, [group_one, group_two])
+    assign(:organizations, [org_one, org_two])
+
+    sign_in create(:admin)
+    render
+  end
+
+  it 'renders a table of providers' do
+    assert_select 'tr>td', text: 'Group One'
+    assert_select 'tr>td', text: 'Group Two'
+  end
+
+  it 'renders a table of organizations' do
+    assert_select 'tr>td', text: 'Organization One'
+    assert_select 'tr>td', text: 'Organization Two'
+  end
+
+  it 'renders the membership status' do
+    assert_select 'tr>td>span', text: 'Member'
+  end
+
+  it 'renders the New group button' do
+    assert_select 'a.btn', text: 'New group', href: new_group_path
+  end
+end

--- a/spec/views/groups/new.html.erb_spec.rb
+++ b/spec/views/groups/new.html.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'groups/new' do
+  before do
+    assign(:group, Group.new)
+    render
+  end
+
+  it 'renders new group form' do
+    assert_select 'form[action=?][method=?]', groups_path, 'post' do
+      assert_select 'input[name=?]', 'group[name]'
+      assert_select 'input[name=?]', 'group[short_name]'
+      assert_select 'input[name=?]', 'group[slug]'
+    end
+  end
+end

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'groups/show' do
+  let(:group) { create(:group_with_organizations) }
+
+  before do
+    assign(:group, group)
+    sign_in create(:admin)
+    render
+  end
+
+  it 'renders the group name and other details' do
+    expect(rendered).to have_css('h1', text: 'A group of organizations')
+    expect(rendered).to have_css('dd', text: 'group-')
+  end
+
+  it 'renders the organizations list' do
+    expect(rendered).to have_css('dt', text: 'Member organizations')
+    expect(rendered).to have_css('li', text: 'Organization', count: 3)
+  end
+
+  it 'renders the edit button' do
+    expect(rendered).to have_link('Edit', href: edit_group_path(group))
+  end
+end

--- a/spec/views/shared/organization_header.html.erb_spec.rb
+++ b/spec/views/shared/organization_header.html.erb_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe 'shared/_organization_header' do
   let(:organization) do
     create(:organization,
            name: 'Best University',
-           code: 'Bst')
+           code: 'Bst',
+           groups: [group])
   end
-
+  let(:group) { create(:group, short_name: 'Group') }
   let(:stream) { create(:stream_with_uploads, organization: organization) }
   let(:user) { create(:user) }
   let(:contact_email) { create(:contact_email, organization: organization) }
@@ -35,5 +36,11 @@ RSpec.describe 'shared/_organization_header' do
     render
 
     expect(view.content_for(:org_header)).to include(contact_email.email)
+  end
+
+  it 'displays the group short name' do
+    render
+
+    expect(view.content_for(:org_header)).to include(group.short_name)
   end
 end


### PR DESCRIPTION
This adds a group model for grouping organizations in POD. Some of this could use review by a UX designer, but I think this is a reasonable start.

Groups can be viewed and managed by POD site admins via the Group link in the header. The Group index page shows all groups in a table, a button to create a new group, and shows a matrix of organizations and group membership.

<img width="1018" height="727" alt="Screenshot 2025-10-21 at 9 04 03 AM" src="https://github.com/user-attachments/assets/c27156a5-7f57-42d0-9ae7-7e5973b2014e" />

Group membership can be edited from each Group's edit or new form:

<img width="615" height="737" alt="Screenshot 2025-10-21 at 9 05 32 AM" src="https://github.com/user-attachments/assets/c2d65bd9-502b-478b-9ac8-66802664afcb" />

A group show page (also only available for POD site admins) show all the group information, including member organizations:

<img width="1164" height="560" alt="Screenshot 2025-10-20 at 9 30 05 AM" src="https://github.com/user-attachments/assets/da590f1d-4f92-4e92-97bb-aec2b11404ae" />

All POD members will see in each organization's header which groups the organization belongs to, along with an icon for the group, if supplied:

<img width="582" height="214" alt="Screenshot 2025-10-20 at 9 28 20 AM" src="https://github.com/user-attachments/assets/fe3ae057-a5aa-4fdc-b109-9b9c67336756" />

<img width="483" height="144" alt="Screenshot 2025-10-20 at 9 27 47 AM" src="https://github.com/user-attachments/assets/3a570c91-16e9-4bc4-9d53-7a77e0033718" />
