### PR TITLE
Remove the stream id from the OAI identifier.

### DIFF
--- a/app/services/oai_marc_record_writer_service.rb
+++ b/app/services/oai_marc_record_writer_service.rb
@@ -48,7 +48,7 @@ class OaiMarcRecordWriterService
 
   # See http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm
   def oai_id(record)
-    "oai:#{Settings.oai_repository_id}:#{record.organization.slug}:#{record.stream.id}:#{record.marc001}"
+    "oai:#{Settings.oai_repository_id}:#{record.organization.slug}:#{record.marc001}"
   end
 
   # Special logic for writing OAI-PMH-style record responses

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe 'OAI-PMH' do
       visit oai_path(verb: 'ListRecords', metadataPrefix: 'marc21')
       doc = Nokogiri::XML(page.body)
       expect(doc.at_css('ListRecords > record > header > identifier').text).to(
-        eq("oai:pod.stanford.edu:my-org:#{organization.default_stream.id}:a12345")
+        eq('oai:pod.stanford.edu:my-org:a12345')
       )
     end
 
@@ -248,7 +248,7 @@ RSpec.describe 'OAI-PMH' do
     context 'when a resumption token is supplied' do
       it 'renders the indicated page of records' do
         visit oai_path(verb: 'ListRecords', resumptionToken: OaiConcern::ResumptionToken.new(page: '2').encode)
-        expect(page).to have_text("oai:pod.stanford.edu:my-org:#{organization.default_stream.id}:DUKE000075163")
+        expect(page).to have_text('oai:pod.stanford.edu:my-org:DUKE000075163')
       end
 
       it 'renders an error if any other argument is also supplied' do


### PR DESCRIPTION
I don't think including the stream id in the OAI identifier is appropriate (although I guess it's possible some harvesters are parsing it to do something?) and including it seems like it makes the "seamless" harvesting (that I guess we abandoned with #1197?) kinda weird?
