### PR TITLE
make token field keyboard accessible

### DIFF
--- a/app/views/allowlisted_jwts/index.html.erb
+++ b/app/views/allowlisted_jwts/index.html.erb
@@ -15,7 +15,7 @@
         <tr data-controller="copy-text">
           <td><%= token.label %> (scope: <%= token.scope %>)</td>
           <td>
-            <div id="token" class="text-monospace w-100 custom-copy-text overflow-auto user-select-all border p-1 text-nowrap" data-copy-text-target="text"><%= token.encoded_token %></div>
+            <div id="token" tabindex="0" class="text-monospace w-100 custom-copy-text overflow-auto user-select-all border p-1 text-nowrap" data-copy-text-target="text"><%= token.encoded_token %></div>
             <i class="small text-muted">
               Last used:
               <% if token.last_used %>


### PR DESCRIPTION
It trips an accessibility error if it isn't keyboard accessible

<img width="377" height="350" alt="Screenshot 2025-10-20 at 1 35 56 PM" src="https://github.com/user-attachments/assets/4b974bde-ce3f-4c7d-b293-9731ccf27f36" />
