### PR TITLE
text break table rows for large tables

### DIFF
--- a/app/components/dashboard/uploads_activity_component.html.erb
+++ b/app/components/dashboard/uploads_activity_component.html.erb
@@ -8,7 +8,7 @@
     <% end %>
   </ul>
 
-  <table class="table table-striped mb-3" id="upload-activity">
+  <table class="table table-striped mb-3 text-break" id="upload-activity">
     <thead>
       <tr>
         <th class="text-center"><%= t('dashboard.summary.table.status') %></th>

--- a/app/views/uploads/_file_table.html.erb
+++ b/app/views/uploads/_file_table.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 </ul>
 
-<table class="table table-striped mb-3">
+<table class="table table-striped mb-3 text-break">
   <thead>
     <th class="text-center">Status</th>
     <th>File</th>


### PR DESCRIPTION
closes #1283 

Before:
<img width="818" height="625" alt="Screenshot 2025-10-20 at 2 25 46 PM" src="https://github.com/user-attachments/assets/78f354e9-bfd3-4f3e-a59d-2216f566d31e" />

After:
<img width="758" height="742" alt="Screenshot 2025-10-20 at 2 16 04 PM" src="https://github.com/user-attachments/assets/7b43c377-f399-4dec-86de-1d3e8e9489be" />

Before:
<img width="809" height="644" alt="Screenshot 2025-10-20 at 2 25 33 PM" src="https://github.com/user-attachments/assets/c43606da-46b0-4d52-9924-fe6d55f205a0" />

After:
<img width="785" height="494" alt="Screenshot 2025-10-20 at 2 18 14 PM" src="https://github.com/user-attachments/assets/ee4b4156-48b7-4af5-90c9-681822aa6316" />
