### PR TITLE
Optimize the NormalizedMarcRecordReader postgres query.

### DIFF
--- a/app/services/normalized_marc_record_reader.rb
+++ b/app/services/normalized_marc_record_reader.rb
@@ -64,8 +64,8 @@ class NormalizedMarcRecordReader
   def __pgsql_current_marc_record_ids
     # Postgres has 'SELECT DISTINCT ON', so we can have the database de-dupe marc records with the same 001
     # and return the most recent
-    inner_query = MarcRecord.select('DISTINCT ON (marc001) *').where(upload: uploads).order(:marc001, file_id: :desc, id: :asc)
-
-    MarcRecord.from(inner_query, :marc_records).order(file_id: :asc, id: :asc).pluck(:id)
+    MarcRecord.select('DISTINCT ON (marc001) marc_records.id')
+              .where(upload: uploads)
+              .order(:marc001, file_id: :desc, id: :asc).ids
   end
 end


### PR DESCRIPTION
I think the inner/outer query business was to try to preserve the originally supplied record order if there weren't a lot of changes, but I'm not sure it's worth any additional overhead 🤷‍♂️ 