### PR TITLE
Add augment_marc flag to NormalizedMarcRecordReader, so we can easily…

### DIFF
--- a/app/services/normalized_marc_record_reader.rb
+++ b/app/services/normalized_marc_record_reader.rb
@@ -9,31 +9,34 @@ class NormalizedMarcRecordReader
   attr_reader :uploads, :thread_pool_size
 
   # @param [Array<Upload>] uploads
-  def initialize(uploads, thread_pool_size: 10)
+  def initialize(uploads, thread_pool_size: 10, augment_marc: true)
     @uploads = uploads
     @thread_pool_size = thread_pool_size
+    @augment_marc = augment_marc
   end
 
   # @yield [MarcRecord]
   def each(...)
-    pool = Concurrent::FixedThreadPool.new(thread_pool_size)
+    pool = Concurrent::FixedThreadPool.new(thread_pool_size) if @augment_marc
 
     current_marc_record_ids.each_slice(200) do |slice|
       records = MarcRecord.includes(:upload, :stream, :organization).find(slice)
 
-      # do a little pre-processing to pre-generated the augmented MARC.
-      # this is done in a thread pool for a marginal performance boost
-      # (10-15%).
-      records.each do |record|
-        pool.post { record.augmented_marc }
-      rescue StandardError
-        nil
+      if @augment_marc
+        # do a little pre-processing to pre-generated the augmented MARC.
+        # this is done in a thread pool for a marginal performance boost
+        # (10-15%).
+        records.each do |record|
+          pool.post { record.augmented_marc }
+        rescue StandardError
+          nil
+        end
       end
 
       records.each(...)
     end
 
-    pool.shutdown
+    pool&.shutdown
   end
 
   # Return the full list of MarcRecord id values to include in the dump.


### PR DESCRIPTION
… re-benchmark the supposed performance improvement.

In current versions of ruby, I'm not sure there's much of a difference, but it'd be nice to prove it one way or another 🤷‍♂️ 