### PR TITLE
Always run a delta dump before doing a full dump.

### DIFF
--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -19,6 +19,8 @@ class GenerateFullDumpJob < ApplicationJob
     now = Time.zone.now
     uploads = stream.uploads.active
 
+    GenerateDeltaDumpJob.perform_now(stream, publish: publish) if stream.current_full_dump
+
     uploads.where.not(status: 'processed').find_each do |upload|
       ExtractMarcRecordMetadataJob.perform_now(upload)
     end


### PR DESCRIPTION
For the best seamless normalized dumps, I think we want to kick off a delta dump before doing a full dump so all the stream changes are in a delta dump somewhere