### PR TITLE
Track the effective date for delta dumps

### DIFF
--- a/app/components/dashboard/normalized_data_tab_component.html.erb
+++ b/app/components/dashboard/normalized_data_tab_component.html.erb
@@ -31,7 +31,7 @@
           <!-- Last delta: -->
           <td>
             <% if dump && dump.deltas.any? %>
-              <%= local_time(dump.deltas.maximum(:created_at), format: datetime_display_format()) %>
+              <%= local_time(dump.deltas.maximum(:effective_date), format: datetime_display_format()) %>
             <% else %>
               <i class="bi bi-exclamation-triangle-fill text-warning"></i>
             <% end %>

--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -8,15 +8,15 @@ class GenerateFullDumpJob < ApplicationJob
   def self.enqueue_all
     Organization.providers.find_each do |org|
       full_dump = org.default_stream.full_dumps.published.last
-      next if full_dump && org.default_stream.uploads.where(updated_at: full_dump.created_at...Time.zone.now).none?
+      next if full_dump && org.default_stream.uploads.where(updated_at: full_dump.effective_date..).none?
 
       GenerateFullDumpJob.perform_later(org.default_stream)
     end
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
   def perform(stream, publish: true)
-    now = Time.zone.now
+    effective_date = Time.zone.now
     uploads = stream.uploads.active
 
     uploads.where.not(status: 'processed').find_each do |upload|
@@ -25,12 +25,12 @@ class GenerateFullDumpJob < ApplicationJob
 
     progress.total = uploads.sum(&:marc_records_count)
 
-    full_dump = stream.full_dumps.build
+    full_dump = stream.full_dumps.build(effective_date: effective_date)
     normalized_dump = full_dump.build_normalized_dump(stream: stream)
 
     base_name = "#{stream.organization.slug}#{"-#{stream.slug}" unless stream.default}-#{Time.zone.today}-full"
     writer = MarcRecordWriterService.new(base_name)
-    oai_writer = ChunkedOaiMarcRecordWriterService.new(base_name, dump: normalized_dump, now: now)
+    oai_writer = ChunkedOaiMarcRecordWriterService.new(base_name, dump: normalized_dump, now: effective_date)
 
     begin
       NormalizedMarcRecordReader.new(uploads).each_slice(1000) do |records|
@@ -57,14 +57,16 @@ class GenerateFullDumpJob < ApplicationJob
       end
 
       # Run manually for now:
-      # GenerateInterstreamDeltaDumpJob.perform_later(stream.current_full_dump, stream, now: now, publish: publish)
+      # GenerateInterstreamDeltaDumpJob.perform_now(
+      #   previous_stream, stream, effective_date: effective_date, publish: publish
+      # )
 
-      normalized_dump.update(published_at: (Time.zone.now if publish))
+      normalized_dump.update(published_at: effective_date)
       full_dump.published_at = Time.zone.now if publish
 
       full_dump.save!
 
-      GenerateDeltaDumpJob.perform_later(stream, publish: publish)
+      GenerateDeltaDumpJob.perform_later(stream, from_date: effective_date, publish: publish)
     ensure
       writer.close
       writer.unlink
@@ -73,7 +75,7 @@ class GenerateFullDumpJob < ApplicationJob
       oai_writer.unlink
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
 
   def human_readable_filename(base_name, file_type)
     as = case file_type

--- a/app/views/streams/normalized_dump.xml.builder
+++ b/app/views/streams/normalized_dump.xml.builder
@@ -32,7 +32,7 @@ xml.urlset(
 
     # deltas
 
-    @normalized_dump.deltas.sort_by(&:created_at).each do |delta|
+    @normalized_dump.deltas.sort_by(&:effective_date).each do |delta|
       file = if params[:flavor] == 'marc21'
                delta.marc21.attachment
              else

--- a/db/migrate/20251022142837_add_effective_date_to_dumps.rb
+++ b/db/migrate/20251022142837_add_effective_date_to_dumps.rb
@@ -1,0 +1,15 @@
+class AddEffectiveDateToDumps < ActiveRecord::Migration[8.0]
+  def change
+    add_column :full_dumps, :effective_date, :datetime
+    add_index :full_dumps, :effective_date
+    add_column :delta_dumps, :effective_date, :datetime
+    add_index :delta_dumps, :effective_date
+
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE full_dumps SET effective_date = created_at WHERE effective_date IS NULL"
+        execute "UPDATE delta_dumps SET effective_date = created_at WHERE effective_date IS NULL"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_20_183942) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_22_142837) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -124,6 +124,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_20_183942) do
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "effective_date"
+    t.index ["effective_date"], name: "index_delta_dumps_on_effective_date"
     t.index ["normalized_dump_id"], name: "index_delta_dumps_on_normalized_dump_id"
     t.index ["previous_stream_id"], name: "index_delta_dumps_on_previous_stream_id"
     t.index ["published_at"], name: "index_delta_dumps_on_published_at"
@@ -147,6 +149,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_20_183942) do
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "effective_date"
+    t.index ["effective_date"], name: "index_full_dumps_on_effective_date"
     t.index ["normalized_dump_id"], name: "index_full_dumps_on_normalized_dump_id"
     t.index ["published_at"], name: "index_full_dumps_on_published_at"
     t.index ["stream_id"], name: "index_full_dumps_on_stream_id"


### PR DESCRIPTION
We're using `created_at` in a couple places to mean "when the data gathering part of the dump happened", but I think being a little more explicit is clearer (+ safer?).