### PR TITLE
Format the timestamp in the delta base name.

### DIFF
--- a/app/jobs/generate_delta_dump_job.rb
+++ b/app/jobs/generate_delta_dump_job.rb
@@ -30,7 +30,7 @@ class GenerateDeltaDumpJob < ApplicationJob
     delta_dump = stream.delta_dumps.build(effective_date: effective_date)
     normalized_dump = delta_dump.build_normalized_dump(stream: stream)
 
-    base_name = "#{stream.organization.slug}#{"-#{stream.slug}" unless stream.default}-#{effective_date}-delta"
+    base_name = "#{stream.organization.slug}#{"-#{stream.slug}" unless stream.default}-#{effective_date.strftime('%FT%T')}-delta"
     writer = MarcRecordWriterService.new(base_name)
     oai_writer = ChunkedOaiMarcRecordWriterService.new(base_name, dump: normalized_dump, now: effective_date)
 


### PR DESCRIPTION
Previously, we were using date granularity. Without doing explicit formatting, we're now getting ugly file names like: `harvard-2025-10-23 07-00-06 UTC-delta-marc21.mrc.gz` 🤷‍♂️ 