### PR TITLE
Add filters to upload table for organizations

### DIFF
--- a/app/assets/stylesheets/files.css
+++ b/app/assets/stylesheets/files.css
@@ -45,3 +45,7 @@
 .box-metadata {
   padding-right: 1rem;
 }
+
+#uploaded-file-filters > li.list-inline-item.active {
+   font-weight: bold;
+}

--- a/app/views/streams/_stream_uploads.html.erb
+++ b/app/views/streams/_stream_uploads.html.erb
@@ -1,7 +1,9 @@
-<%= render 'uploads/file_table' do %>
-    <% uploads.each do |upload| %>
-      <%= render 'uploads/file_rows', upload: upload %>
-    <% end %>
-<% end %>
+<turbo-frame id="stream-upload-files">
+  <%= render 'uploads/file_table', filtering_enabled: true do %>
+      <% uploads.each do |upload| %>
+        <%= render 'uploads/file_rows', upload: upload %>
+      <% end %>
+  <% end %>
 
-<%= paginate uploads %>
+  <%= paginate uploads %>
+</turbo-frame>

--- a/app/views/uploads/_file_rows.html.erb
+++ b/app/views/uploads/_file_rows.html.erb
@@ -27,7 +27,14 @@
     <%= render 'uploads/file_rows', upload: u %>
   <% end %>
 <% end %>
-<% upload.files.each do |file| %>
+<% files_to_render = if params[:filter].present?
+                        upload.files.select { |f| f.pod_metadata_status.to_s == params[:filter].to_s }
+                      else
+                        upload.files
+                      end %>
+
+<% files_to_render.each do |file| %>
+
   <tr>
     <td class="align-middle text-center">
       <%= render(MetadataStatusIconComponent.new(status: file.pod_metadata_status)) %>

--- a/app/views/uploads/_file_table.html.erb
+++ b/app/views/uploads/_file_table.html.erb
@@ -1,9 +1,21 @@
-<ul class="table-key list-unstyled list-inline pt-3" aria-hidden="true">
-  <% Settings.metadata_status.keys.each do |status| %>
-    <li class="list-inline-item">
-      <%= render(MetadataStatusIconComponent.new(status: status, show_label: true)) %>
+<ul class="table-key list-unstyled list-inline pt-3" id="uploaded-file-filters">
+  <% Settings.metadata_status.each do |status, _values| %>
+    <li class="list-inline-item <%= 'active' if @current_filter == status.to_s %>">
+      <% if local_assigns[:filtering_enabled] %>
+        <%= link_to organization_stream_path(@organization, @stream, filter: status), data: { turbo_frame: 'stream-upload-files' } do %>
+          <%= render(MetadataStatusIconComponent.new(status: status, show_label: true)) %>
+        <% end %>
+      <% else %>
+        <%= render(MetadataStatusIconComponent.new(status: status, show_label: true)) %>
+      <% end %>
     </li>
   <% end %>
+
+<% if local_assigns[:filtering_enabled] %>
+  <li class="list-inline-item">
+    <%= link_to "Clear filter", organization_stream_path(@organization, @stream), data: { turbo_frame: 'stream-upload-files' }, class: 'btn btn-link btn-sm' %>
+  </li>
+<% end %>
 </ul>
 
 <table class="table table-striped mb-3 text-break">

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'uploading files to POD' do
     it 'allows an org owner to upload a file to the default stream' do
       visit '/'
 
-      click_on 'Best University home'
+      visit organization_stream_path(organization, stream)
       click_on 'New upload'
       attach_file('file', Rails.root.join('spec/fixtures/stanford-50.mrc.gz'))
       click_on 'Create upload'


### PR DESCRIPTION
Closes #1262 

You can view this at URLs like `/organizations/cornell/streams/48d9316f-85fc-4e38-8dcb-b22f1407301c`

Because the `views/uploads/_file_table.html.erb` is used by two different controllers / show pages -- uploads and streams -- this got a little weird. Both views want to render the table, but the internal paths for filtering are different -- and in the case of `/uploads/:id` we don't even want the filtering. 