### PR TITLE
Remove DefaultStreamHistories in favor of just using Stream#status

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,34 +18,34 @@ module ApplicationHelper
     local_time(time, format: datetime_display_format, class: "hidden-popover-time d-none #{time_type}")
   end
 
-  def badge_popover_text(history)
-    if history.end_time.present?
-      concat(hidden_time(history.start_time, 'start'))
-      concat(hidden_time(history.end_time, 'end'))
+  def badge_popover_text(stream)
+    if stream.default?
+      concat(hidden_time(stream.created_at, 'default'))
     else
-      concat(hidden_time(history.start_time, 'default'))
+      concat(hidden_time(stream.created_at, 'start'))
+      concat(hidden_time(stream.updated_at, 'end'))
     end
   end
 
-  def default_stream_status_badge(stream)
-    badge_class = stream.default? ? 'btn-info' : 'btn-warning'
-    badge_label = stream.default? ? 'Default ' : 'Previous default '
+  def stream_status_badge(stream)
+    badge_label = case stream.status
+                  when 'default' then 'Default'
+                  when 'previous-default' then 'Previous default'
+                  end
+
+    return if badge_label.blank?
 
     # popovers are added to <button> elements for accessibility.
     # See https://getbootstrap.com/docs/5.0/components/popovers
     content_tag(:button,
                 href: '#',
-                class: "badge text-dark btn #{badge_class}",
+                class: "badge text-dark btn #{stream.default? ? 'btn-info' : 'btn-warning'}",
                 'data-bs-toggle': 'popover',
                 'data-bs-placement': 'top',
                 'data-bs-html': 'true') do
       concat(badge_label)
       concat(content_tag(:i, nil, class: 'bi bi-info-circle-fill text-dark'))
-      stream.default_stream_histories.recent.collect do |history|
-        next unless history.start_time
-
-        badge_popover_text(history)
-      end
+      badge_popover_text(stream)
     end
   end
 end

--- a/app/jobs/generate_delta_dump_job.rb
+++ b/app/jobs/generate_delta_dump_job.rb
@@ -30,7 +30,7 @@ class GenerateDeltaDumpJob < ApplicationJob
     delta_dump = stream.delta_dumps.build(effective_date: effective_date)
     normalized_dump = delta_dump.build_normalized_dump(stream: stream)
 
-    base_name = "#{stream.organization.slug}#{"-#{stream.slug}" unless stream.default}-#{effective_date.strftime('%FT%T')}-delta"
+    base_name = "#{stream.organization.slug}#{"-#{stream.slug}" unless stream.default?}-#{effective_date.strftime('%FT%T')}-delta"
     writer = MarcRecordWriterService.new(base_name)
     oai_writer = ChunkedOaiMarcRecordWriterService.new(base_name, dump: normalized_dump, now: effective_date)
 

--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -48,7 +48,7 @@ class GenerateFullDumpJob < ApplicationJob
     full_dump = stream.full_dumps.build(effective_date: effective_date)
     normalized_dump = full_dump.build_normalized_dump(stream: stream)
 
-    base_name = "#{stream.organization.slug}#{"-#{stream.slug}" unless stream.default}-#{Time.zone.today}-full"
+    base_name = "#{stream.organization.slug}#{"-#{stream.slug}" unless stream.default?}-#{Time.zone.today}-full"
     writer = MarcRecordWriterService.new(base_name)
     oai_writer = ChunkedOaiMarcRecordWriterService.new(base_name, dump: normalized_dump, now: effective_date)
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -72,8 +72,8 @@ class Ability
     can :read, ActiveStorage::Attachment, { record: { organization: { id: member_orgs } } }
 
     # Must be last
-    cannot :destroy, Stream.previous_default, organization: { id: owned_orgs }
-    cannot :destroy, Stream, default: true
+    cannot :destroy, Stream, status: %w[previous-default] unless user.has_role?(:admin)
+    cannot :destroy, Stream, status: %w[default]
   end
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity

--- a/app/models/default_stream_history.rb
+++ b/app/models/default_stream_history.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # History of an organizations' default streams
+# @deprecated
 class DefaultStreamHistory < ApplicationRecord
   belongs_to :stream
-  has_one :organization, through: :stream, inverse_of: :default_stream_histories
-  scope :recent, -> { order(start_time: :desc) }
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,7 +9,6 @@ class Organization < ApplicationRecord
   friendly_id :name, use: %i[finders slugged]
   has_paper_trail
   has_many :streams, dependent: :destroy
-  has_many :default_stream_histories, through: :streams, inverse_of: :organization
   has_many :uploads, through: :streams
   has_many :marc_records, through: :streams, inverse_of: :organization
   has_many :allowlisted_jwts, as: :resource, dependent: :delete_all
@@ -25,7 +24,7 @@ class Organization < ApplicationRecord
   validates :marc_docs_url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), allow_blank: true }
 
   def default_stream
-    @default_stream ||= streams.find_or_create_by(default: true)
+    @default_stream ||= streams.find_or_create_by(status: 'default')
   end
 
   def jwt_token

--- a/app/models/overview.rb
+++ b/app/models/overview.rb
@@ -18,7 +18,7 @@ class Overview
     @last_upload ||=
       Upload.includes(:organization, :stream)
             .where(organization: { provider: true, public: true })
-            .where(stream: { default: true })
+            .where(stream: { status: 'default' })
             .order(created_at: :desc)
             .first
   end

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -8,39 +8,35 @@ class Stream < ApplicationRecord
   friendly_id :name, use: %i[finders slugged scoped], scope: :organization
   belongs_to :organization
   has_many :uploads, dependent: :destroy_async
-  has_many :default_stream_histories, dependent: :delete_all
+  has_many :default_stream_histories, dependent: :delete_all, deprecated: true
   has_many :marc_records, through: :uploads, inverse_of: :stream
   has_many :files, source: :files_attachments, through: :uploads
   has_one :statistic, dependent: :delete, as: :resource
   has_many :full_dumps, dependent: :destroy_async
   has_many :delta_dumps, dependent: :destroy_async
   has_many :job_trackers, dependent: :delete_all, as: :reports_on
+  belongs_to :previous_stream, class_name: 'Stream', optional: true
 
-  scope :default, -> { where(default: true) }
-  scope :previous_default, -> { joins(:default_stream_histories).where(default: false).distinct }
-  scope :active, -> { where(status: %w[active pending]) }
+  scope :default, -> { where(status: 'default') }
+  scope :active, -> { where(status: %w[active pending default previous-default]) }
   scope :pending, -> { where(status: 'pending') }
   scope :archived, -> { where(status: 'archived') }
-
-  after_create :check_for_a_default_stream
-
-  before_update :update_default_stream_history, if: :default_changed?
 
   def display_name
     name.presence || default_name
   end
 
   def archive
-    update(status: 'archived', default: false)
+    update(status: 'archived')
     uploads.find_each(&:archive)
   end
 
   def make_default
-    return if default
+    return if default?
 
     Stream.transaction do
-      organization.streams.default.each { |stream| stream.update(default: false) }
-      update(default: true)
+      organization.streams.default.each { |stream| stream.update(status: 'previous-default') }
+      update(status: 'default')
     end
   end
 
@@ -90,24 +86,14 @@ class Stream < ApplicationRecord
     status == 'pending'
   end
 
+  def default?
+    status == 'default'
+  end
+
   private
 
   def default_name
-    "#{I18n.l(created_at.to_date)} - #{I18n.l(updated_at.to_date) unless default?}"
-  end
-
-  def check_for_a_default_stream
-    return unless organization.streams.one?
-
-    DefaultStreamHistory.create(stream: self, start_time: DateTime.now)
-  end
-
-  def update_default_stream_history
-    if default
-      DefaultStreamHistory.create(stream: self, start_time: DateTime.now)
-    else
-      organization.default_stream_histories.where(end_time: nil).update(end_time: DateTime.now)
-    end
+    "#{I18n.l(created_at.to_date)} - #{I18n.l(updated_at.to_date) unless updated_at.nil? || default?}"
   end
 
   def statistic_up_to_date?

--- a/app/views/organizations/_organization.json.jbuilder
+++ b/app/views/organizations/_organization.json.jbuilder
@@ -5,6 +5,6 @@ json.url organization_url(organization, format: :json)
 json.streams organization.streams do |stream|
   json.id stream.id
   json.name stream.name
-  json.default stream.default
+  json.default stream.default?
   json.url organization_stream_url(organization, stream, format: :json)
 end

--- a/app/views/streams/_header.html.erb
+++ b/app/views/streams/_header.html.erb
@@ -2,7 +2,7 @@
   <h2 class="font-weight-normal mb-0">Stream: <%= stream.display_name %></h2>
 
   <div class="p-2">
-    <%= default_stream_status_badge(stream) if stream.default_stream_histories.any? %>
+    <%= stream_status_badge(stream) %>
     <%= link_to can?(:edit, stream) ? t('.manage_streams') : t('.view_streams'), organization_streams_path(stream.organization) %>
     <span class="badge bg-secondary"><%= stream.organization.streams.active.count %></span>
   </div>

--- a/app/views/streams/index.html.erb
+++ b/app/views/streams/index.html.erb
@@ -24,7 +24,7 @@
         <td><%= link_to stream.display_name, organization_stream_path(@organization, stream) %></td>
         <td><%= stream.slug %></td>
         <td>
-          <%= default_stream_status_badge(stream) if stream.default_stream_histories.any? %>
+          <%= stream_status_badge(stream) %>
         </td>
         <td class=""><%= local_time(stream.updated_at, format: datetime_display_format()) %></td>
         <td class="text-end"><%= stream.cached_files_count %></td>

--- a/db/migrate/20251023185446_add_previous_stream_id_to_streams.rb
+++ b/db/migrate/20251023185446_add_previous_stream_id_to_streams.rb
@@ -1,0 +1,5 @@
+class AddPreviousStreamIdToStreams < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :streams, :previous_stream, null: true, foreign_key: false
+  end
+end

--- a/db/migrate/20251023185916_migrate_stream_data_to_status.rb
+++ b/db/migrate/20251023185916_migrate_stream_data_to_status.rb
@@ -1,0 +1,10 @@
+class MigrateStreamDataToStatus < ActiveRecord::Migration[8.0]
+  def up
+    Stream.where(default: true).update_all(status: 'default')
+    Stream.where(id: DefaultStreamHistory.where.not(end_time: nil).joins(:stream).where('stream.status': 'active').pluck(:stream_id)).update_all(status: 'previous-default')
+  end
+
+  def down
+    Stream.where(status: 'default').update_all(default: true)
+  end
+end

--- a/spec/factories/stream.rb
+++ b/spec/factories/stream.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     end
 
     trait :default do
-      default { true }
+      status { 'default' }
     end
   end
 end

--- a/spec/features/normalized_download_spec.rb
+++ b/spec/features/normalized_download_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Downloading normalized files from POD' do
   let(:organization) { create(:organization, code: 'best-org') }
-  let(:stream) { create(:stream, organization: organization, default: true) }
+  let(:stream) { create(:stream, organization: organization, status: 'default') }
   let(:user) { create(:user) }
 
   before do
@@ -18,7 +18,7 @@ RSpec.describe 'Downloading normalized files from POD' do
   describe 'Full dumps' do
     before do
       allow(Time.zone).to receive(:today).and_return('2020-01-01')
-      GenerateFullDumpJob.perform_now(organization.default_stream)
+      GenerateFullDumpJob.perform_now(stream)
     end
 
     it 'generates binary & xml full dump files and provides a link to them' do

--- a/spec/features/streams_spec.rb
+++ b/spec/features/streams_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'uploading files to POD' do
   context 'with an organization user' do
     let(:organization) { create(:organization, name: 'Best University') }
-    let(:stream) { create(:stream, organization: organization, default: true) }
+    let(:stream) { create(:stream, organization: organization, status: 'default') }
     let(:user) { create(:user) }
 
     before do

--- a/spec/jobs/promote_stream_to_default_job_spec.rb
+++ b/spec/jobs/promote_stream_to_default_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PromoteStreamToDefaultJob do
   it 'makes the pending stream the default stream' do
     described_class.perform_now(new_pending_stream)
 
-    expect(current_default_stream.reload).to have_attributes default: false
-    expect(new_pending_stream.reload).to have_attributes default: true
+    expect(current_default_stream.reload).to have_attributes default?: false
+    expect(new_pending_stream.reload).to have_attributes default?: true
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -53,16 +53,10 @@ RSpec.describe Ability do
     let(:organization) { create(:organization) }
     let(:not_my_org) { create(:organization) }
     let(:default_stream) { create(:stream, :default, organization: organization) }
-    let(:previous_default_stream) { create(:stream, organization: organization) }
+    let(:previous_default_stream) { create(:stream, status: 'previous-default', organization: organization) }
 
     context 'with an admin' do
       let(:user) { create(:admin) }
-
-      before do
-        # add previous_default_stream to the history
-        DefaultStreamHistory.create(stream_id: previous_default_stream.id, start_time: '2022-04-15 13:29:21',
-                                    end_time: '2022-04-15 13:30:21')
-      end
 
       it { is_expected.to be_able_to(:manage, :all) }
       it { is_expected.not_to be_able_to(:destroy, default_stream) }
@@ -84,9 +78,6 @@ RSpec.describe Ability do
 
       before do
         user.add_role :owner, organization
-        # add previous_default_stream to the history
-        DefaultStreamHistory.create(stream_id: previous_default_stream.id, start_time: '2022-04-15 13:29:21',
-                                    end_time: '2022-04-15 13:30:21')
       end
 
       it { is_expected.not_to be_able_to(:destroy, default_stream) }

--- a/spec/models/default_stream_history_spec.rb
+++ b/spec/models/default_stream_history_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe DefaultStreamHistory do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/stream_spec.rb
+++ b/spec/models/stream_spec.rb
@@ -51,45 +51,18 @@ RSpec.describe Stream do
     end
   end
 
-  describe '#default_stream_histories' do
-    it 'creates a default stream history when the first stream is created in an organization' do
-      org = create(:organization)
-      described_class.create({ organization: org, default: true })
-      described_class.create({ organization: org, default: true })
-      expect(org.default_stream_histories.count).to be(1)
-    end
-
-    it 'creates a new default stream history when stream becomes the default' do
-      org = create(:organization)
-      described_class.create({ organization: org, default: true })
-      second_stream = described_class.create({ organization: org, default: false })
-
-      second_stream.update(default: true)
-      expect(DefaultStreamHistory.all[1].end_time).to be_nil
-    end
-
-    it 'updates and appends endtime to prior default stream history when the stream is no longer the default' do
-      org = create(:organization)
-      first_stream = described_class.create({ organization: org, default: true })
-      described_class.create({ organization: org, default: false })
-
-      first_stream.update(default: false)
-      expect(DefaultStreamHistory.all[0].end_time).not_to be_nil
-    end
-  end
-
   describe '#make_default' do
-    let!(:current_default) { create(:stream, organization: organization, default: true) }
+    let!(:current_default) { create(:stream, organization: organization, status: 'default') }
 
     it 'makes the current stream the only default' do
       expect do
         stream.make_default
-      end.to(change(stream, :default).from(false).to(true)
-         .and(change { current_default.reload.default }.from(true).to(false)))
+      end.to(change(stream, :default?).from(false).to(true)
+         .and(change { current_default.reload.default? }.from(true).to(false)))
     end
 
     it 'does not do anything if the stream is already the default' do
-      expect { current_default.make_default }.not_to(change { current_default.reload.default })
+      expect { current_default.make_default }.not_to(change { current_default.reload.default? })
     end
   end
 end


### PR DESCRIPTION
I'm not sure that `DefaultStreamHistories` does anything special that we don't already know, except perhaps making (perhaps) a more accurate history if a previously default stream is made the default again. I'm not sure that exception is worth the complexity?