### PR TITLE
Calculate statuses per organization on the activities page

### DIFF
--- a/app/components/dashboard/summary_component.html.erb
+++ b/app/components/dashboard/summary_component.html.erb
@@ -35,7 +35,7 @@
     <div class="tab-content pt-3" id="summary-tabs-content">
       <!-- Uploads tab - rendered by default, not lazy-loaded -->
       <div id="uploads-pane" class="tab-pane fade show active" role="tabpanel">
-        <%= render Dashboard::UploadsTabComponent.new(uploads: @uploads) %>
+        <%= render Dashboard::UploadsTabComponent.new %>
       </div>
 
       <!-- Job Status tab -->

--- a/app/components/dashboard/uploads_tab_component.html.erb
+++ b/app/components/dashboard/uploads_tab_component.html.erb
@@ -38,20 +38,16 @@
           </td>
           <!-- Date of successful upload: -->
           <td>
-            <% if uploads.present? %>
-              <% if last_successful_upload_date %>
-                <%= helpers.local_time(last_successful_upload_date, format: helpers.datetime_display_format()) %>
-              <% else %>
-                <p>No prior successful uploads</p>
-              <% end %>
+            <% if last_successful_upload_date = provider.uploads.where(status: 'processed', marc_records_count: 1..).maximum(:created_at) %>
+              <%= helpers.local_time(last_successful_upload_date, format: helpers.datetime_display_format()) %>
             <% else %>
-              <i class="bi bi-exclamation-triangle-fill text-warning"></i>
+              <p>No prior successful uploads</p>
             <% end %>
           </td>
           <!-- Did any uploads succeed in past 30 days? -->
           <td class="text-center">
             <% if provider.upload_in_last_30_days? %>
-              <% status = best_status %>
+              <% status = best_status(uploads) %>
               <%= render JobStatusIconComponent.new(status: status) %>
             <% else %>
               <p class="mb-0">No uploads in last 30 days</p>

--- a/app/components/dashboard/uploads_tab_component.rb
+++ b/app/components/dashboard/uploads_tab_component.rb
@@ -7,37 +7,23 @@ module Dashboard
 
     delegate :local_time, :datetime_display_format, to: :helpers
 
-    def initialize(uploads:)
-      @uploads = uploads
-      super()
-    end
-
     def recent_uploads_by_provider
       @recent_uploads_by_provider ||= Organization.providers.index_with do |org|
         org.uploads.recent.where('uploads.created_at > ?', 30.days.ago)
       end
     end
 
-    def last_successful_upload_date
-      @last_successful_upload_date ||=
-        @uploads.find { |upload| files_status(upload) == :completed }&.created_at
-    end
-
-    def status
-      @status ||= best_status
-    end
-
-    private
-
     # Return the most successful status level given a set up uploads
-    def best_status
-      statuses = @uploads.map { |upload| files_status(upload) }.uniq
+    def best_status(uploads)
+      statuses = uploads.map { |upload| files_status(upload) }.uniq
 
       return :completed if statuses.include? :completed
       return :needs_attention if statuses.include? :needs_attention
 
       :failed if statuses.include? :failed
     end
+
+    private
 
     # Status criteria outlined in https://github.com/pod4lib/aggregator/issues/674
     # Completed - When all files in the upload are flagged as valid MARC or deletes


### PR DESCRIPTION
I suspect the refactor in #1267 pushed some memoization to the wrong level, so we're using the same data in each row of the activities table:

<img width="677" height="525" alt="Screenshot 2025-10-24 at 11 40 55" src="https://github.com/user-attachments/assets/720071e5-2eb9-43ea-bdf8-707cdf43d89e" />
