### PR TITLE
Ignore scoped order for Organization.find_each

### DIFF
--- a/app/jobs/cleanup_and_remove_data_job.rb
+++ b/app/jobs/cleanup_and_remove_data_job.rb
@@ -3,7 +3,7 @@
 # Cleanup data per data retention policy
 class CleanupAndRemoveDataJob < ApplicationJob
   def self.enqueue_all
-    Organization.find_each { |org| CleanupAndRemoveDataJob.perform_later(org) }
+    Organization.unscope(:order).find_each { |org| CleanupAndRemoveDataJob.perform_later(org) }
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/app/jobs/update_organization_statistics_job.rb
+++ b/app/jobs/update_organization_statistics_job.rb
@@ -6,7 +6,7 @@ class UpdateOrganizationStatisticsJob < ApplicationJob
   sidekiq_options retry: 1
 
   def self.perform_all
-    Organization.find_each do |o|
+    Organization.unscope(:order).find_each do |o|
       perform_later(o.default_stream) unless o.default_stream&.statistic&.updated_at&.today?
     end
   end


### PR DESCRIPTION
...so we are no longer warned that scoped order is ignored.