### PR TITLE
Separate token and user ability rules into separate classes

### DIFF
--- a/app/controllers/concerns/custom_pod_ability_concern.rb
+++ b/app/controllers/concerns/custom_pod_ability_concern.rb
@@ -4,7 +4,11 @@
 # A concern to add the a custom current_ability
 module CustomPodAbilityConcern
   def current_ability
-    @current_ability ||= Ability.new(current_user, current_token)
+    @current_ability ||= if current_token
+                           TokenAbility.new(current_token)
+                         else
+                           Ability.new(current_user)
+                         end
   end
 
   def current_token

--- a/app/models/token_ability.rb
+++ b/app/models/token_ability.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Ability class that defines token-based abilities
+class TokenAbility < Ability
+  def initialize(token)
+    super(nil)
+
+    @token = token
+    @allowlisted_jwt = AllowlistedJwt.find_by(jti: token_jti)
+
+    return unless token
+
+    any_token_abilities
+    scoped_token_abilities
+  end
+
+  private
+
+  def any_token_abilities
+    can :read, Organization, allowlisted_jwts: { jti: token_jti }
+  end
+
+  # Scoped token abilities:
+  # - 'all' scope: upload and download abilities
+  # - 'upload' scope: upload abilities only
+  # - 'download' scope: download abilities only
+  def scoped_token_abilities
+    case allowlisted_jwt.scope
+    when 'all'
+      token_upload_abilities
+      token_download_abilities
+    when 'upload'
+      token_upload_abilities
+    when 'download'
+      token_download_abilities
+    end
+
+    allowlisted_jwt&.update(updated_at: Time.zone.now)
+  end
+
+  def token_upload_abilities
+    can %i[create update], [Stream, Upload], organization: { allowlisted_jwts: { jti: token_jti } }
+  end
+
+  def token_download_abilities
+    can :read, Organization, public: true
+    can :read, [Stream, Upload], organization: { public: true }
+    can :read, ActiveStorage::Attachment, { record: { organization: { public: true } } }
+  end
+
+  def token_jti
+    @token['jti'] if @token
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -4,49 +4,12 @@ require 'rails_helper'
 require 'cancan/matchers'
 
 RSpec.describe Ability do
-  subject { described_class.new(user, token) }
+  subject { described_class.new(user) }
 
   let(:user) { nil }
-  let(:token) { nil }
 
   describe 'for an anonymous user' do
     it { is_expected.to be_able_to(:confirm, ContactEmail) }
-  end
-
-  describe 'with a token' do
-    let(:org1) { create(:organization) }
-    let(:org2) { create(:organization) }
-    let(:default_stream) { create(:stream, :default) }
-    let(:token) { { 'jti' => 'anything' } }
-    let(:token_attributes) { {} }
-
-    before do
-      AllowlistedJwt.create(resource: org1, jti: 'anything', **token_attributes)
-    end
-
-    it { is_expected.to be_able_to(:read, org1) }
-    it { is_expected.to be_able_to(:read, org2) }
-
-    it { is_expected.to be_able_to(:create, Upload.new(organization: org1)) }
-    it { is_expected.not_to be_able_to(:create, Upload.new(organization: org2)) }
-
-    context 'with a token scoped to reads' do
-      let(:token_attributes) { { scope: 'download' } }
-
-      it { is_expected.to be_able_to(:read, org1) }
-      it { is_expected.to be_able_to(:read, org2) }
-      it { is_expected.to be_able_to(:read, create(:upload, :binary_marc, organization: org1)) }
-      it { is_expected.to be_able_to(:read, create(:upload, :binary_marc, organization: org2)) }
-      it { is_expected.not_to be_able_to(:create, Upload.new(organization: org1)) }
-    end
-
-    context 'with a token scoped to upload' do
-      let(:token_attributes) { { scope: 'upload' } }
-
-      it { is_expected.to be_able_to(:read, org1) }
-      it { is_expected.not_to be_able_to(:read, org2) }
-      it { is_expected.to be_able_to(:create, Upload.new(organization: org1)) }
-    end
   end
 
   describe 'with a user' do

--- a/spec/models/token_ability_spec.rb
+++ b/spec/models/token_ability_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'cancan/matchers'
+
+RSpec.describe TokenAbility do
+  subject { described_class.new(token) }
+
+  let(:token) { nil }
+
+  describe 'for an anonymous user' do
+    it { is_expected.to be_able_to(:confirm, ContactEmail) }
+  end
+
+  describe 'with a token' do
+    let(:org_one) { create(:organization) }
+    let(:org_two) { create(:organization) }
+    let(:default_stream) { create(:stream, :default) }
+    let(:token) { { 'jti' => 'anything' } }
+    let(:token_attributes) { {} }
+
+    before do
+      AllowlistedJwt.create(resource: org_one, jti: 'anything', **token_attributes)
+    end
+
+    it { is_expected.to be_able_to(:read, org_one) }
+    it { is_expected.to be_able_to(:read, org_two) }
+
+    it { is_expected.to be_able_to(:create, Upload.new(organization: org_one)) }
+    it { is_expected.not_to be_able_to(:create, Upload.new(organization: org_two)) }
+
+    context 'with a token scoped to reads' do
+      let(:token_attributes) { { scope: 'download' } }
+
+      it { is_expected.to be_able_to(:read, org_one) }
+      it { is_expected.to be_able_to(:read, org_two) }
+      it { is_expected.to be_able_to(:read, create(:upload, :binary_marc, organization: org_one)) }
+      it { is_expected.to be_able_to(:read, create(:upload, :binary_marc, organization: org_two)) }
+      it { is_expected.not_to be_able_to(:create, Upload.new(organization: org_one)) }
+    end
+
+    context 'with a token scoped to upload' do
+      let(:token_attributes) { { scope: 'upload' } }
+
+      it { is_expected.to be_able_to(:read, org_one) }
+      it { is_expected.not_to be_able_to(:read, org_two) }
+      it { is_expected.to be_able_to(:create, Upload.new(organization: org_one)) }
+    end
+  end
+end


### PR DESCRIPTION
Maybe this will make adding _even more_ ability rules set by organizations somewhat more palatable.