### PR TITLE
Run UpdateOrganizationStatisticsJob after running ExtractMarcRecordMetadataJob (again) to try to keep data up to date.

### DIFF
--- a/app/jobs/extract_marc_record_metadata_job.rb
+++ b/app/jobs/extract_marc_record_metadata_job.rb
@@ -32,6 +32,9 @@ class ExtractMarcRecordMetadataJob < ApplicationJob
       job_tracker.update(progress: total, total: total)
 
       upload.update(status: 'processed', marc_records_count: total, deletes_count: deletes)
+
+      # Schedule a job to update organization statistics, with a little delay to try to debounce multiple uploads
+      UpdateOrganizationStatisticsJob.set(wait: 1.minute).perform_later(upload.stream)
     end
   end
 end

--- a/app/jobs/update_organization_statistics_job.rb
+++ b/app/jobs/update_organization_statistics_job.rb
@@ -4,6 +4,7 @@
 class UpdateOrganizationStatisticsJob < ApplicationJob
   queue_as :default
   retry_on StandardError, wait: :exponentially_longer, attempts: 1
+  limits_concurrency key: ->(stream) { stream }, duration: 3.hours, on_conflict: :discard
 
   def self.perform_all
     Organization.unscope(:order).find_each do |o|


### PR DESCRIPTION
... because I'm always getting confused locally why the stream data isn't right. We stopped doing this in [#976](https://github.com/pod4lib/aggregator/pull/976) for performance(?) reasons.