### PR TITLE
Clean up layout if there were no successful uploads

### DIFF
--- a/app/components/dashboard/uploads_tab_component.html.erb
+++ b/app/components/dashboard/uploads_tab_component.html.erb
@@ -37,7 +37,7 @@
               <%= render StatusIcons::MetadataStatusIconComponent.new(status: last_successful_upload.metadata_status) %>
               <%= link_to helpers.local_time(last_successful_upload.created_at, format: helpers.datetime_display_format()), organization_upload_path(provider, last_successful_upload)  %>
             <% else %>
-              <p>No prior successful uploads</p>
+              <p class="mb-0">No prior successful uploads</p>
             <% end %>
           </td>
         </tr>


### PR DESCRIPTION
... to remove the extra padding here:

<img width="402" height="245" alt="Screenshot 2025-10-31 at 12 18 48" src="https://github.com/user-attachments/assets/a73b4a8c-15f0-4537-8ad1-1806adb3cc73" />
