### PR TITLE
Link to the organization page, not the uploads#index page

### DIFF
--- a/app/components/dashboard/uploads_tab_component.html.erb
+++ b/app/components/dashboard/uploads_tab_component.html.erb
@@ -15,7 +15,7 @@
           <td class="text-center">
             <%= provider_status_icon(uploads) %>
           </td>
-          <th class="fw-normal"><%= link_to provider.name, organization_uploads_path(provider) %></th>
+          <th class="fw-normal"><%= link_to provider.name, organization_path(provider) %></th>
           
           <!-- Did any uploads succeed in past 30 days? -->
           <td>


### PR DESCRIPTION
Part of #1394 . I don't think uploads#index is useful for regular users 🤷‍♂️ 