### PR TITLE
Expose file analysis errors on the uploads#info page

### DIFF
--- a/app/views/uploads/info.html.erb
+++ b/app/views/uploads/info.html.erb
@@ -11,6 +11,12 @@
     </div>
   </div>
 
+  <% if @blob.metadata&.dig('error').present? %>
+    <div class="alert alert-warning">
+      <%= @blob.metadata['error'] %>
+    </div>
+  <% end %>
+
   <%= render 'uploads/summary_card', upload: @upload %>
 
   <%= turbo_frame_tag 'marc-records', src: organization_upload_attachment_marc_records_path(@upload.organization, @upload, @attachment) %>


### PR DESCRIPTION
<img width="746" height="417" alt="Screenshot 2025-11-04 at 13 57 37" src="https://github.com/user-attachments/assets/9b81d546-7671-4a83-8b48-c89960672ef2" />

🤷‍♂️ 

NCSU gave us a file with a little bit of bad XML:

```xml
...
    <datafield reached the end
tag="340" ind1=" " ind2=" ">
      <subfield code="b">1 1/4 in.</subfield>
    </datafield>
...
```