### PR TITLE
Remove guard clause around ExtractMarcRecordMetadataJob

### DIFF
--- a/app/jobs/extract_marc_record_metadata_job.rb
+++ b/app/jobs/extract_marc_record_metadata_job.rb
@@ -4,10 +4,9 @@
 class ExtractMarcRecordMetadataJob < ApplicationJob
   queue_as :default
   with_job_tracking
+  limits_concurrency key: ->(upload) { upload }, duration: 30.minutes
 
   def perform(upload) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-    return unless upload.active? && upload.files.any?
-
     upload.with_lock do
       upload.update(status: 'active')
 


### PR DESCRIPTION
I'm not sure what this guard clause is meant to be guarding against.. The best I can figure is it's trying to do some concurrency control and stop us from processing the same file multiple times, but I don't think it's doing that (effectively.) and instead it is just  annoying for local development 🤷‍♂️ 