### PR TITLE
Remove reference to jobs tab/component from dashboard controller

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -10,8 +10,6 @@ class DashboardController < ApplicationController
 
   def tab
     case params[:tab]
-    when 'job_status'
-      render Dashboard::JobStatusTabComponent.new
     when 'normalized_data'
       render Dashboard::NormalizedDataTabComponent.new
     when 'users'


### PR DESCRIPTION
We removed the rest of the jobs tab stuff here: https://github.com/pod4lib/aggregator/pull/1424