### PR TITLE
Add `.pod-icon` class to fallback status icons. Fixes #1413

### DIFF
--- a/app/components/dashboard/normalized_data_tab_component.html.erb
+++ b/app/components/dashboard/normalized_data_tab_component.html.erb
@@ -17,7 +17,7 @@
               <% if dump && dump.created_at %>
                 <%= local_time(dump.created_at, format: datetime_display_format()) %>
               <% else %>
-                <i class="bi bi-exclamation-triangle-fill text-warning"></i>
+                <i class="bi bi-exclamation-triangle-fill text-warning pod-icon"></i>
               <% end %>
           </td>
           <!-- Dump records: -->
@@ -33,7 +33,7 @@
             <% if dump && dump.deltas.any? %>
               <%= local_time(dump.deltas.maximum(:effective_date), format: datetime_display_format()) %>
             <% else %>
-              <i class="bi bi-exclamation-triangle-fill text-warning"></i>
+              <i class="bi bi-exclamation-triangle-fill text-warning pod-icon"></i>
             <% end %>
           </td>
         </tr>

--- a/app/components/dashboard/uploads_tab_component.html.erb
+++ b/app/components/dashboard/uploads_tab_component.html.erb
@@ -27,7 +27,7 @@
               <%= render StatusIcons::UploadStatusIconComponent.new(status: upload.metadata_status) %>
               <%= link_to helpers.local_time(upload.created_at, format: helpers.datetime_display_format()), organization_upload_path(provider, upload) %>
             <% else %>
-              <i class="bi bi-exclamation-triangle-fill text-warning"></i>
+              <i class="bi bi-exclamation-triangle-fill text-warning pod-icon"></i>
             <% end %>
           </td>
         </tr>


### PR DESCRIPTION
I guess it makes sense that icons by themselves in columns are bigger than icons inline with text 🤷‍♂️ 