### PR TITLE
Remove commented out summary tab

### DIFF
--- a/app/components/activity/summary_component.html.erb
+++ b/app/components/activity/summary_component.html.erb
@@ -13,12 +13,6 @@
       <button class="nav-link" id="normalized-data-tab" data-bs-toggle="tab" data-bs-target="#normalized-data-pane"
         type="button" role="tab" aria-controls="normalized-data-pane" aria-selected="false">Normalized data</button>
     </li>
-    <!-- TODO: Files tab. See https://github.com/pod4lib/aggregator/issues/677
-    <li class="nav-item" role="presentation">
-      <button class="nav-link" id="files-tab" data-bs-toggle="tab" data-bs-target="#files-pane" type="button" role="tab"
-        aria-controls="files-pane" aria-selected="false">Files</button>
-    </li>
-    -->
     <li class="nav-item" role="presentation">
       <button class="nav-link" id="users-tab" data-bs-toggle="tab" data-bs-target="#users-pane" type="button" role="tab"
         aria-controls="users-pane" aria-selected="false">Users</button>


### PR DESCRIPTION
I'm guessing we're not going to add a files tab to the Activity page. The designs in https://github.com/pod4lib/aggregator/issues/677 mostly duplicate what's already displayed on the Provider index page.