### PR TITLE
Remove public flag from organizations

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -30,19 +30,19 @@ class Ability
   end
 
   def all_user_abilities
-    can :read, Organization, public: true
-    can :read, :dashboard if Organization.exists?(public: true)
+    can :read, Organization
+    can :read, :dashboard
   end
 
   def user_with_roles_abilities
     return if user.roles.empty?
 
-    can :read, ActiveStorage::Attachment, { record: { organization: { public: true } } }
-    can :read, MarcRecord, upload: { organization: { public: true } }
-    can %i[read profile normalized_data processing_status], Stream, organization: { public: true }
-    can %i[read info], Upload, organization: { public: true }
+    can :read, ActiveStorage::Attachment
+    can :read, MarcRecord
+    can %i[read profile normalized_data processing_status], Stream
+    can %i[read info], Upload
     can :read, :pages_data
-    can %i[read users organization_details provider_details], Organization, public: true
+    can %i[read users organization_details provider_details], Organization
   end
 
   def site_admin_user_abilities

--- a/app/models/overview.rb
+++ b/app/models/overview.rb
@@ -17,7 +17,7 @@ class Overview
   def last_upload
     @last_upload ||=
       Upload.includes(:organization, :stream)
-            .where(organization: { provider: true, public: true })
+            .where(organization: { provider: true })
             .where(stream: { status: 'default' })
             .order(created_at: :desc)
             .first
@@ -53,8 +53,8 @@ class Overview
 
   private
 
-  # public organizations that provide data to the aggregator
+  # provider organizations that provide data to the aggregator
   def providers
-    @providers ||= Organization.where(provider: true, public: true)
+    @providers ||= Organization.where(provider: true)
   end
 end

--- a/app/models/token_ability.rb
+++ b/app/models/token_ability.rb
@@ -43,9 +43,9 @@ class TokenAbility < Ability
   end
 
   def token_download_abilities
-    can :read, Organization, public: true
-    can :read, [Stream, Upload], organization: { public: true }
-    can :read, ActiveStorage::Attachment, { record: { organization: { public: true } } }
+    can :read, Organization
+    can :read, [Stream, Upload]
+    can :read, ActiveStorage::Attachment
   end
 
   def token_jti

--- a/db/migrate/20251107184730_remove_public_flag_from_organizations.rb
+++ b/db/migrate/20251107184730_remove_public_flag_from_organizations.rb
@@ -1,0 +1,5 @@
+class RemovePublicFlagFromOrganizations < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :organizations, :public, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_03_172808) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_07_184730) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -242,7 +242,6 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_03_172808) do
     t.string "name"
     t.json "normalization_steps"
     t.boolean "provider", default: true
-    t.boolean "public", default: true
     t.string "slug"
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_organizations_on_slug", unique: true


### PR DESCRIPTION
All organizations on pod-prod are currently "public", so this flag isn't doing anything for us any more (and is more confusing than helpful)