### PR TITLE
Remove redundant ActiveStorage::Attachment read ability

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -79,7 +79,6 @@ class Ability
     can %i[create], [Upload], organization: { id: member_organization_ids }
     can :read, MarcRecord, upload: { organization: { id: member_organization_ids } }
     can :read, AllowlistedJwt, resource_type: 'Organization', resource_id: member_organization_ids
-    can :read, ActiveStorage::Attachment, { record: { organization: { id: member_organization_ids } } }
   end
 
   def member_organization_ids


### PR DESCRIPTION
We already grant all users with roles `can :read, ActiveStorage::Attachment`. We don't need a special ability to do this for a member of an organization. I think this mattered before we removed the public flag.