### PR TITLE
Remove redundant MarcRecord read ability

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -77,7 +77,6 @@ class Ability
     can :read, :dashboard
     can %i[invite], Organization, id: member_organization_ids
     can %i[create], [Upload], organization: { id: member_organization_ids }
-    can :read, MarcRecord, upload: { organization: { id: member_organization_ids } }
     can :read, AllowlistedJwt, resource_type: 'Organization', resource_id: member_organization_ids
     can :read, ActiveStorage::Attachment, { record: { organization: { id: member_organization_ids } } }
   end


### PR DESCRIPTION
We already grant all users with roles `can :read, MarcRecord`. We don't need to also permit organization members this ability on their organization. I think this mattered before we removed the public flag.