### PR TITLE
Remove redundant dashboard abilities

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -53,14 +53,12 @@ class Ability
     return unless user.acting_as_superadmin?
 
     can :manage, :all
-    can :manage, :dashboard_controller
     can :manage, :organization_slug
   end
 
   def organization_owner_abilities
     return if owned_organization_ids.empty?
 
-    can :read, :dashboard
     can :manage, Organization, id: owned_organization_ids
     can :crud, Stream, organization: { id: owned_organization_ids }
     can :crud, Upload, organization: { id: owned_organization_ids }


### PR DESCRIPTION
As far as I can tell there is no such thing as `dashboard_controller` ability and we already grant organization members `    can :read, :dashboard`. Since all organization owners are also members we don't need to also authorize this for organization owners.