### PR TITLE
Move consumer-only org table below provider table

### DIFF
--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,48 +1,7 @@
 <div class="container index-page">
   <h1 class="visually-hidden">Providers</h1>
-  <!-- Only show consumer-only table to admins -->
-  <% if can?(:view, :consumers) && @consumers.any? %>
-    <h2>Consumer-only organizations</h2>
-    <table class="table table-striped organizations mb-5 mt-4" id="consumers">
-      <thead>
-        <tr>
-          <th colspan="2">Consumer</th>
-          <th class="text-end">Users</th>
-          <th>POD contact</th>
-          <% if can? :manage, Organization %>
-            <th colspan="2">Actions</th>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody>
-        <% @consumers.each do |organization| %>
-          <tr>
-            <td class="align-middle text-center icon-column">
-              <% if organization.icon.attached? %>
-                <%= image_tag(organization.icon, alt: '', class: 'icon-sm') %>
-              <% end %>
-            </td>
-            <td class="align-middle">
-              <%= link_to organization.name, organization %>
-            </td>
-            <td class="align-middle text-end"><%= organization.users.count %></td>
-            <td class="align-middle">
-              <% if organization.contact_email.present? %>
-                <span class="lead"><%= mail_to organization.contact_email.email %></span>
-              <% end %>
-            </td>
-            <% if can? :manage, Organization %>
-              <td class="align-middle"><%= link_to 'Edit', organization_details_organization_path(organization), class: 'btn btn-secondary btn-sm' if can? :edit, organization %></td>
-              <td class="align-middle"><%= link_to 'Delete', organization, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' if can? :destroy, organization %></td>
-            <% end %>
 
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  <% end %>
-
-  <h2 class="pt-4">Default stream statistics by provider</h2>
+  <h2>Default stream statistics by provider</h2>
   <p>
     Statistics are calculated daily and might not reflect the most recent uploads.
   </p>
@@ -96,6 +55,50 @@
   <br>
   <% if can? :manage, Organization %>
     <%= link_to 'New organization', new_organization_path, class: 'btn btn-primary' if can? :create, Organization.new %>
+  <% end %>
+
+  <!-- Only show consumer-only table to admins -->
+  <% if can?(:view, :consumers) && @consumers.any? %>
+    <div class="mt-5">
+      <h2>Consumer-only organizations</h2>
+      <table class="table table-striped organizations mb-5 mt-4" id="consumers">
+        <thead>
+          <tr>
+            <th colspan="2">Consumer</th>
+            <th class="text-end">Users</th>
+            <th>POD contact</th>
+            <% if can? :manage, Organization %>
+              <th colspan="2">Actions</th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <% @consumers.each do |organization| %>
+            <tr>
+              <td class="align-middle text-center icon-column">
+                <% if organization.icon.attached? %>
+                  <%= image_tag(organization.icon, alt: '', class: 'icon-sm') %>
+                <% end %>
+              </td>
+              <td class="align-middle">
+                <%= link_to organization.name, organization %>
+              </td>
+              <td class="align-middle text-end"><%= organization.users.count %></td>
+              <td class="align-middle">
+                <% if organization.contact_email.present? %>
+                  <span class="lead"><%= mail_to organization.contact_email.email %></span>
+                <% end %>
+              </td>
+              <% if can? :manage, Organization %>
+                <td class="align-middle"><%= link_to 'Edit', organization_details_organization_path(organization), class: 'btn btn-secondary btn-sm' if can? :edit, organization %></td>
+                <td class="align-middle"><%= link_to 'Delete', organization, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' if can? :destroy, organization %></td>
+              <% end %>
+
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   <% end %>
 
 </div>


### PR DESCRIPTION
We mostly care about what providers are up to. Let's move the consumer-only table (only visible to POD admins) below the table of providers:

<img width="995" height="1005" alt="Screenshot 2025-11-10 at 3 21 41 PM" src="https://github.com/user-attachments/assets/2a8069f1-5a25-49cb-ba69-28fea6be02c1" />
