### PR TITLE
Show a consumer-only badge in the org header

### DIFF
--- a/app/views/shared/_organization_header.html.erb
+++ b/app/views/shared/_organization_header.html.erb
@@ -30,6 +30,9 @@
           <span class="lead"><%= mail_to @organization.contact_email.email, t('.contact') %></span>
         <% end %>
       </div>
+      <% unless @organization.provider? %>
+        <span class="badge text-bg-info h-100 my-auto ms-4">Consumer-only</span>
+      <% end %>
       <div class="ms-auto">
         <% if content_for? :org_header_section_link %>
           <%= content_for :org_header_section_link %>

--- a/spec/views/shared/organization_header.html.erb_spec.rb
+++ b/spec/views/shared/organization_header.html.erb_spec.rb
@@ -18,29 +18,36 @@ RSpec.describe 'shared/_organization_header' do
     assign(:organization, organization)
     assign(:stream, stream)
     assign(:contact_email, contact_email)
+    render
   end
 
   it 'displays the organization name' do
-    render
-
     expect(view.content_for(:org_header)).to include(organization.name)
   end
 
   it 'displays the organization code' do
-    render
-
     expect(view.content_for(:org_header)).to include(organization.code)
   end
 
   it 'displays the organization contact email' do
-    render
-
     expect(view.content_for(:org_header)).to include(contact_email.email)
   end
 
   it 'displays the group short name' do
-    render
-
     expect(view.content_for(:org_header)).to include(group.short_name)
+  end
+
+  it 'does not display the consumer-only badge' do
+    expect(view.content_for(:org_header)).not_to include('Consumer-only')
+  end
+
+  context 'when the organization is consumer-only' do
+    let(:organization) do
+      create(:organization, :consumer)
+    end
+
+    it 'displays the consumer-only badge' do
+      expect(view.content_for(:org_header)).to include('Consumer-only')
+    end
   end
 end


### PR DESCRIPTION
Display a consumer-only badge in the org header.
<img width="647" height="429" alt="Screenshot 2025-11-10 at 3 53 33 PM" src="https://github.com/user-attachments/assets/f1115c72-06a5-4fd4-82ee-35d515073559" />
