### PR TITLE
Convert 4-space indent to 2-space indent

### DIFF
--- a/app/views/organization_users/index.html.erb
+++ b/app/views/organization_users/index.html.erb
@@ -1,47 +1,47 @@
 <%= render 'shared/layout_manage_organization' do %>
-    <h3><%= t('organization_users.index.title') %></h3>
-    <%= link_to t('organization_users.index.invite_user'), organization_invite_new_path(@organization), class: 'btn btn-sm btn-primary mt-3' if can? :manage, @organization %>
-    <table class="table table-striped organizations mt-4">
-        <thead>
-            <tr>
-                <th scope="col"><%= t('organization_users.index.email') %></th>
-                <th scope="col"><%= t('organization_users.index.name') %></th>
-                <th scope="col"><%= t('organization_users.index.job_title') %></th>
-                <% if can? :manage, @organization %>
-                <th scope="col" class="text-center"><%= t('organization_users.index.is_owner') %></th>
-                <th scope="col" class="text-center"><%= t('organization_users.index.actions') %></th>
+  <h3><%= t('organization_users.index.title') %></h3>
+  <%= link_to t('organization_users.index.invite_user'), organization_invite_new_path(@organization), class: 'btn btn-sm btn-primary mt-3' if can? :manage, @organization %>
+  <table class="table table-striped organizations mt-4">
+    <thead>
+      <tr>
+        <th scope="col"><%= t('organization_users.index.email') %></th>
+        <th scope="col"><%= t('organization_users.index.name') %></th>
+        <th scope="col"><%= t('organization_users.index.job_title') %></th>
+        <% if can? :manage, @organization %>
+          <th scope="col" class="text-center"><%= t('organization_users.index.is_owner') %></th>
+          <th scope="col" class="text-center"><%= t('organization_users.index.actions') %></th>
+        <% else %>
+          <th scope="col"><%= t('organization_users.index.role') %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+        <% @organization.users.each do |user| %>
+          <tr>
+            <td class="align-middle"><%= mail_to user.email %></td>
+            <td class="align-middle"><%= user.name %></td>
+            <td class="align-middle"><%= user.title %></td>
+            <% if can? :manage, @organization %>
+              <td class="text-center align-middle">
+                <div class="form-check align-middle d-inline-block">
+                <% if user.roles.map{|r| r['name']}.include? "owner" %>
+                  <%= link_to '', organization_user_path(@organization, user, remove_role: 'owner'), data: { turbo_method: :patch, turbo_confirm: t('organization_users.index.confirm_action') }, class: 'form-check-input checked', title: t('organization_users.index.remove_owner') %>
+                  <input class="form-check-input pe-none" type="checkbox" aria-label="Organization owner?" checked>
                 <% else %>
-                <th scope="col"><%= t('organization_users.index.role') %></th>
+                  <%= link_to '', organization_user_path(@organization, user, add_role: 'owner'), data: { turbo_method: :patch, turbo_confirm: t('organization_users.index.confirm_action') }, class: 'form-check-input', title: t('organization_users.index.add_owner') %>
                 <% end %>
-            </tr>
-        </thead>
-        <tbody>
-            <% @organization.users.each do |user| %>
-            <tr>
-                <td class="align-middle"><%= mail_to user.email %></td>
-                <td class="align-middle"><%= user.name %></td>
-                <td class="align-middle"><%= user.title %></td>
-                <% if can? :manage, @organization %>
-                    <td class="text-center align-middle">
-                        <div class="form-check align-middle d-inline-block">
-                        <% if user.roles.map{|r| r['name']}.include? "owner" %>
-                            <%= link_to '', organization_user_path(@organization, user, remove_role: 'owner'), data: { turbo_method: :patch, turbo_confirm: t('organization_users.index.confirm_action') }, class: 'form-check-input checked', title: t('organization_users.index.remove_owner') %>
-                            <input class="form-check-input pe-none" type="checkbox" aria-label="Organization owner?" checked>
-                        <% else %>
-                            <%= link_to '', organization_user_path(@organization, user, add_role: 'owner'), data: { turbo_method: :patch, turbo_confirm: t('organization_users.index.confirm_action') }, class: 'form-check-input', title: t('organization_users.index.add_owner') %>
-                        <% end %>
-                        </div>
-                    </td>
-                    <td class="align-middle text-center">
-                        <%= link_to t('organization_users.index.remove_user'), organization_user_path(@organization, user), data: { turbo_method: :delete, turbo_confirm: t('organization_users.index.confirm_action') }, class: 'btn btn-danger btn-sm' %>
-                    </td>
-                <% else %>
-                    <td class="align-middle">
-                        <%= if user.roles.map{|r| r['name']}.include? "owner" then "Owner" else "Member" end %>
-                    </td>
-                <% end %>
-            </tr>
+                </div>
+              </td>
+              <td class="align-middle text-center">
+                <%= link_to t('organization_users.index.remove_user'), organization_user_path(@organization, user), data: { turbo_method: :delete, turbo_confirm: t('organization_users.index.confirm_action') }, class: 'btn btn-danger btn-sm' %>
+              </td>
+            <% else %>
+              <td class="align-middle">
+                <%= if user.roles.map{ |r| r['name'] }.include? "owner" then "Owner" else "Member" end %>
+              </td>
             <% end %>
-        </tbody>
-    </table>
+          </tr>
+        <% end %>
+    </tbody>
+  </table>
 <% end %>

--- a/app/views/organizations/provider_details.html.erb
+++ b/app/views/organizations/provider_details.html.erb
@@ -1,46 +1,47 @@
 <%= render 'shared/layout_manage_organization' do %>
 
-    <h3>Provider details</h3>
+  <h3>Provider details</h3>
 
-    <!-- Admin/owner view: -->
-    <% if can? :manage, @organization %>
-        <%= bootstrap_form_with(model: @organization, local: true) do |form| %>
-            <%= render 'provider_details_form', organization: @organization, form: form %>
-            <div class="actions">
-                <%= form.primary 'Update provider details' %>
-            </div>
-        <% end %>
-
-    <!-- Member view: -->
-    <% else %>
-        <dl class="organization-details mt-4">
-            <dt>Local MARC profile documentation</dt>
-            <dd>
-              <p class="<%= @organization.marc_docs_url.blank? ? 'fst-italic' : '' %>">
-                <%= @organization.marc_docs_url.blank? ? 'no value provided' : link_to(@organization.marc_docs_url, @organization.marc_docs_url) %>
-              </p>
-            </dd>
-            <dt>What MARC field contains item-level information?</dt>
-            <dd>
-                <p class="<%= @organization.normalization_steps.values.dig(0, 'source_tag').blank? ? 'fst-italic' : '' %>">
-                <%= @organization.normalization_steps.values.dig(0, 'source_tag').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'source_tag') %>
-                </p>
-            </dd>
-
-            <dt>Local identifier subfield</dt>
-            <dd>
-                <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'i').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'i').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'i') %></p>
-            </dd>
-
-            <dt>Call number subfield</dt>
-            <dd>
-                <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'a').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'a').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'a') %></p>
-            </dd>
-
-            <dt>Local library</dt>
-            <dd>
-            <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'm').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'm').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'm') %></p>
-            </dd>
-        </dl>
+  <!-- Admin/owner view: -->
+  <% if can? :manage, @organization %>
+    <%= bootstrap_form_with(model: @organization, local: true) do |form| %>
+      <%= render 'provider_details_form', organization: @organization, form: form %>
+      <div class="actions">
+        <%= form.primary 'Update provider details' %>
+      </div>
     <% end %>
+
+  <!-- Member view: -->
+  <% else %>
+    <dl class="organization-details mt-4">
+      <dt>Local MARC profile documentation</dt>
+      <dd>
+        <p class="<%= @organization.marc_docs_url.blank? ? 'fst-italic' : '' %>">
+          <%= @organization.marc_docs_url.blank? ? 'no value provided' : link_to(@organization.marc_docs_url, @organization.marc_docs_url) %>
+        </p>
+      </dd>
+
+      <dt>What MARC field contains item-level information?</dt>
+      <dd>
+        <p class="<%= @organization.normalization_steps.values.dig(0, 'source_tag').blank? ? 'fst-italic' : '' %>">
+        <%= @organization.normalization_steps.values.dig(0, 'source_tag').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'source_tag') %>
+        </p>
+      </dd>
+
+      <dt>Local identifier subfield</dt>
+      <dd>
+        <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'i').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'i').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'i') %></p>
+      </dd>
+
+      <dt>Call number subfield</dt>
+      <dd>
+        <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'a').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'a').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'a') %></p>
+      </dd>
+
+      <dt>Local library</dt>
+      <dd>
+        <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'm').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'm').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'm') %></p>
+      </dd>
+    </dl>
+  <% end %>
 <% end %>

--- a/app/views/shared/_layout_upload_page.html.erb
+++ b/app/views/shared/_layout_upload_page.html.erb
@@ -1,6 +1,5 @@
 <%= render 'shared/organization_header' %>
 
-<div class="container manage-organization-container">
-    
-    <%= yield %>
+<div class="container manage-organization-container">  
+  <%= yield %>
 </div>

--- a/app/views/shared/_stream_page_header.html.erb
+++ b/app/views/shared/_stream_page_header.html.erb
@@ -1,18 +1,18 @@
 <%= render 'streams/summary_card', stream: @stream %>
 
 <div class="d-flex flex-row justify-content-center">
-    <div class="btn-group manage-organization-tabs" role="group" aria-label="Manage organization tabs">
-        <% if @stream.default? %>
-            <!-- Use the organization_path aka "Provider home" for the Uploads tab on organization/show -->
-            <%= link_to "Uploads", organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_path(@organization))}" %>
-        <% else %>
-            <%= link_to "Uploads", organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(organization_stream_path(@organization, @stream))}" %>
-        <% end %>
+  <div class="btn-group manage-organization-tabs" role="group" aria-label="Manage organization tabs">
+    <% if @stream.default? %>
+      <!-- Use the organization_path aka "Provider home" for the Uploads tab on organization/show -->
+      <%= link_to "Uploads", organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_path(@organization))}" %>
+    <% else %>
+      <%= link_to "Uploads", organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(organization_stream_path(@organization, @stream))}" %>
+    <% end %>
 
-        <%= link_to "Normalized data", normalized_data_organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(normalized_data_organization_stream_path(@organization, @stream))}" %>
+    <%= link_to "Normalized data", normalized_data_organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(normalized_data_organization_stream_path(@organization, @stream))}" %>
 
-        <%= link_to "Processing status", processing_status_organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(processing_status_organization_stream_path(@organization, @stream))}" %>
+    <%= link_to "Processing status", processing_status_organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(processing_status_organization_stream_path(@organization, @stream))}" %>
 
-        <%= link_to "MARC records", organization_stream_marc_records_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(organization_stream_marc_records_path(@organization, @stream))}" %>
-    </div>
+    <%= link_to "MARC records", organization_stream_marc_records_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(organization_stream_marc_records_path(@organization, @stream))}" %>
+  </div>
 </div>


### PR DESCRIPTION
For whatever reason a few of our templates were using 4 spaces to indent rather than 2. This just converts the indents to 2 spaces -- no code changes.

Turn on hide whitespace to ease review.