### PR TITLE
Check for stream read ability before rendering content and links

### DIFF
--- a/app/views/organizations/_organization.json.jbuilder
+++ b/app/views/organizations/_organization.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.extract! organization, :id, :name, :slug, :groups, :created_at, :updated_at
 json.url organization_url(organization, format: :json)
-json.streams organization.streams do |stream|
+json.streams organization.streams.accessible_by(current_ability) do |stream|
   json.id stream.id
   json.name stream.name
   json.default stream.default?

--- a/app/views/organizations/index.xml.builder
+++ b/app/views/organizations/index.xml.builder
@@ -16,6 +16,8 @@ xml.sitemapindex(
   xml.tag!('rs:ln', rel: 'up', href: href)
   xml.tag!('rs:md', capability: 'resourcelist', at: Time.zone.now.iso8601)
   @organizations.each do |org|
+    next unless can? :read, org.default_stream
+
     xml.sitemap do
       xml.tag!(
         'rs:md',

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,5 +1,6 @@
 <%= render 'shared/layout_stream_page' do %>
-  <h3>Uploads</h3>
-
-  <%= turbo_frame_tag @organization.default_stream, 'uploads', loading: 'lazy', src: organization_uploads_path(@organization, stream: @organization.default_stream, **upload_filter_params) %>
+  <% if can? :read, @organization.default_stream %>
+    <h3>Uploads</h3>
+    <%= turbo_frame_tag @organization.default_stream, 'uploads', loading: 'lazy', src: organization_uploads_path(@organization, stream: @organization.default_stream, **upload_filter_params) %>
+  <% end %>
 <% end %>

--- a/app/views/shared/_stream_page_header.html.erb
+++ b/app/views/shared/_stream_page_header.html.erb
@@ -1,18 +1,20 @@
 <%= render 'streams/summary_card', stream: @stream %>
 
-<div class="d-flex flex-row justify-content-center">
-  <div class="btn-group manage-organization-tabs" role="group" aria-label="Manage organization tabs">
-    <% if @stream.default? %>
-      <!-- Use the organization_path aka "Provider home" for the Uploads tab on organization/show -->
-      <%= link_to "Uploads", organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_path(@organization))}" %>
-    <% else %>
-      <%= link_to "Uploads", organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(organization_stream_path(@organization, @stream))}" %>
-    <% end %>
+<% if can? :read, @stream %>
+  <div class="d-flex flex-row justify-content-center">
+    <div class="btn-group manage-organization-tabs" role="group" aria-label="Manage organization tabs">
+      <% if @stream.default? %>
+        <!-- Use the organization_path aka "Provider home" for the Uploads tab on organization/show -->
+        <%= link_to "Uploads", organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_path(@organization))}" %>
+      <% else %>
+        <%= link_to "Uploads", organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(organization_stream_path(@organization, @stream))}" %>
+      <% end %>
 
-    <%= link_to "Normalized data", normalized_data_organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(normalized_data_organization_stream_path(@organization, @stream))}" %>
+      <%= link_to "Normalized data", normalized_data_organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(normalized_data_organization_stream_path(@organization, @stream))}" %>
 
-    <%= link_to "Processing status", processing_status_organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(processing_status_organization_stream_path(@organization, @stream))}" %>
+      <%= link_to "Processing status", processing_status_organization_stream_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(processing_status_organization_stream_path(@organization, @stream))}" %>
 
-    <%= link_to "MARC records", organization_stream_marc_records_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(organization_stream_marc_records_path(@organization, @stream))}" %>
+      <%= link_to "MARC records", organization_stream_marc_records_path(@organization, @stream), class: "btn btn-outline-primary #{current_page_class(organization_stream_marc_records_path(@organization, @stream))}" %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/streams/_header.html.erb
+++ b/app/views/streams/_header.html.erb
@@ -3,8 +3,10 @@
 
   <div class="p-2">
     <%= render StreamBadgeComponent.new(stream: stream) %>
-    <%= link_to can?(:edit, stream) ? t('.manage_streams') : t('.view_streams'), organization_streams_path(stream.organization) %>
-    <span class="badge bg-secondary"><%= stream.organization.streams.active.count %></span>
+    <% if can? :read, stream %>
+      <%= link_to can?(:edit, stream) ? t('.manage_streams') : t('.view_streams'), organization_streams_path(stream.organization) %>
+      <span class="badge bg-secondary"><%= stream.organization.streams.active.count %></span>
+    <% end %>
   </div>
 
   <div class="ms-auto p-2">

--- a/app/views/streams/show.html.erb
+++ b/app/views/streams/show.html.erb
@@ -1,4 +1,6 @@
 <%= render 'shared/layout_stream_page' do %>
-  <h3>Uploads</h3>
-  <%= turbo_frame_tag @stream, 'uploads', loading: 'lazy', src: organization_uploads_path(@stream.organization, stream: @stream) %>
+  <% if can? :read, @stream %>
+    <h3>Uploads</h3>
+    <%= turbo_frame_tag @stream, 'uploads', loading: 'lazy', src: organization_uploads_path(@stream.organization, stream: @stream) %>
+  <% end %>
 <% end %>

--- a/spec/views/shared/stream_page_header.html.erb_spec.rb
+++ b/spec/views/shared/stream_page_header.html.erb_spec.rb
@@ -5,19 +5,30 @@ require 'rails_helper'
 RSpec.describe 'shared/_stream_page_header' do
   let(:organization) { create(:organization, name: 'Best University') }
   let(:stream) { create(:stream, organization: organization) }
+  let(:current_user) { create(:user) }
 
   before do
     assign(:organization, organization)
     assign(:stream, stream)
   end
 
-  # rubocop:disable RSpec/MultipleExpectations
-  it 'displays the tab links for all users' do
+  it 'does not display uploads for users without the proper role' do
+    sign_in current_user
     render
 
-    expect(rendered).to have_link('Uploads')
-    expect(rendered).to have_link('Normalized data')
-    expect(rendered).to have_link('Processing status')
+    expect(rendered).to have_no_link('Uploads')
   end
-  # rubocop:enable RSpec/MultipleExpectations
+
+  context 'when user is an organization member' do
+    before do
+      current_user.add_role :member, organization
+      sign_in current_user
+      render
+    end
+
+    it 'displays the upload links' do
+      expect(rendered).to have_link('Uploads')
+      expect(rendered).to have_link('Normalized data')
+    end
+  end
 end


### PR DESCRIPTION
Some set up for a future where not all users will be able to read all organizations' streams.