### PR TITLE
Rescue from AccessDenied and return forbidden

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|
       format.json { head :forbidden, content_type: 'text/html' }
+      format.xml { head :forbidden, content_type: 'text/html' }
       format.html { redirect_to main_app.root_url, notice: exception.message, status: :see_other }
       format.js   { head :forbidden, content_type: 'text/html' }
     end

--- a/app/controllers/proxy_controller.rb
+++ b/app/controllers/proxy_controller.rb
@@ -15,6 +15,10 @@ class ProxyController < ActiveStorage::BaseController
     render json: { error: exception.message }, status: :not_found
   end
 
+  rescue_from CanCan::AccessDenied do |exception|
+    render json: { error: exception.message }, status: :forbidden
+  end
+
   # rubocop:disable Metrics/AbcSize
   def show
     attachment = ActiveStorage::Attachment.find(params[:id])


### PR DESCRIPTION
When not all orgs/users can view all streams it will be possible to be denied access to xml resources and files so we should rescue and return 403 forbidden in these cases.

applies to requests like:

- `/organizations/cornell/streams/e2519e69-0762-4384-8902-b6c0aea3acb3/resourcelist`
- `/file/9/cornell-incr-2025-04-12.xml.gz`

