### PR TITLE
Add destroy action to let admins delete users outside of the org context

### DIFF
--- a/app/controllers/site_users_controller.rb
+++ b/app/controllers/site_users_controller.rb
@@ -20,4 +20,13 @@ class SiteUsersController < ApplicationController
     end
   end
   # rubocop:enable Metrics/AbcSize
+
+  def destroy
+    @user.destroy
+
+    respond_to do |format|
+      format.html { redirect_to site_users_url, notice: 'User was successfully deleted.', status: :see_other }
+      format.json { head :no_content }
+    end
+  end
 end

--- a/app/views/site_users/index.html.erb
+++ b/app/views/site_users/index.html.erb
@@ -10,6 +10,7 @@
         <th scope="col"><%= t('.login_count') %></th>
         <th scope="col"><%= t('.last_login') %></th>
         <th scope="col" class="text-center"><%= t('.is_admin') %></th>
+        <th scope="col" class="text-center"><%= t('.actions') %></th>
       </tr>
     </thead>
     <tbody>
@@ -36,12 +37,17 @@
         <td class="text-center align-middle">
           <div class="form-check align-middle d-inline-block">
             <% if user.has_role? :admin %>
-            <%= link_to '', site_user_path(user, remove_role: 'admin'), data: { turbo_method: :patch, turbo_confirm: t('organization_users.index.confirm_action') }, class: 'form-check-input checked', title: t('.remove_admin') %>
-            <input class="form-check-input pe-none" type="checkbox" aria-label="Pod admin?" checked>
+              <%= link_to '', site_user_path(user, remove_role: 'admin'), data: { turbo_method: :patch, turbo_confirm: t('organization_users.index.confirm_action') }, class: 'form-check-input checked', title: t('.remove_admin') %>
+              <input class="form-check-input pe-none" type="checkbox" aria-label="Pod admin?" checked>
             <% else %>
-            <%= link_to '', site_user_path(user, add_role: 'admin'), data: { turbo_method: :patch, turbo_confirm: t('organization_users.index.confirm_action') }, class: 'form-check-input', title: t('.add_admin') %>
+              <%= link_to '', site_user_path(user, add_role: 'admin'), data: { turbo_method: :patch, turbo_confirm: t('organization_users.index.confirm_action') }, class: 'form-check-input', title: t('.add_admin') %>
             <% end %>
           </div>
+        </td>
+        <td class="text-center align-middle">
+          <% if can? :delete, user %>
+            <%= link_to '', site_user_path(user), data: { turbo_method: :delete, turbo_confirm: t('organization_users.index.confirm_delete') }, class: 'text-danger bi bi-trash', title: t('.delete_user') %>
+          <% end %>
         </td>
       </tr>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
       actions: Action
       add_owner: Add owner role
       confirm_action: Are you sure?
+      confirm_delete: Are you sure you want to delete this user?
       created_at: Created
       email: Email address
       invite_user: Invite new user to organization
@@ -173,7 +174,9 @@ en:
     disclaimed_superadmin: You are no longer a superadmin.
   site_users:
     index:
+      actions: Actions
       add_admin: Add admin role
+      delete_user: Delete user
       is_admin: POD admin?
       last_login: Last login
       login_count: Login count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,7 @@ Rails.application.routes.draw do
   end
 
   resources :groups
-  resources :site_users, only: [:index, :update]
+  resources :site_users, only: [:index, :update, :destroy]
 
   authenticate :user, lambda { |u| u.has_role? :admin } do
     mount MissionControl::Jobs::Engine, at: "/jobs", as: 'jobs'


### PR DESCRIPTION
🤷‍♂️ 
<img width="642" height="274" alt="Screenshot 2025-11-12 at 09 35 14" src="https://github.com/user-attachments/assets/c09ac681-7f75-4826-85e1-0bbaa37f812c" />
