### PR TITLE
Change icon for non group members

### DIFF
--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -71,7 +71,7 @@
                     <i class="bi bi-check-circle-fill text-success"></i>
                     <span class="visually-hidden">Member</span>
                   <% else %>
-                    <i class="bi bi-dash-circle"></i>
+                    <i class="bi bi-dash"></i>
                     <span class="visually-hidden">Not a member</span>
                   <% end %>
                 </td>


### PR DESCRIPTION
I think this is easier to read than the current dash-circle icon.

<img width="499" height="151" alt="Screenshot 2025-11-13 at 10 00 19 AM" src="https://github.com/user-attachments/assets/684d16fc-4f0d-44f0-ad05-115399d37980" />
