### PR TITLE
Add restrict_downloads field to organizations to limit access to uploads/records

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -90,7 +90,7 @@ class OrganizationsController < ApplicationController
   def organization_params
     params
       .expect(
-        organization: [:name, :slug, :icon, :code, :provider, :marc_docs_url,
+        organization: [:name, :slug, :icon, :code, :provider, :marc_docs_url, :restrict_downloads,
                        { contact_email_attributes: %i[email],
                          normalization_steps: [[:destination_tag, :source_tag, { subfields: %i[i a m] }]] }]
       )

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,11 +34,15 @@ class Ability
   def user_with_roles_abilities
     return if user.roles.empty?
 
-    can :read, ActiveStorage::Attachment
-    can :read, MarcRecord
-    can :read, Stream
-    can :read, Upload
     can :read, :pages_data
+    organization_ability_restrictions
+  end
+
+  def organization_ability_restrictions(restrictions = { restrict_downloads: false })
+    can :read, ActiveStorage::Attachment, { record: { organization: restrictions } }
+    can :read, MarcRecord, upload: { organization: restrictions }
+    can :read, Stream, organization: restrictions
+    can :read, Upload, organization: restrictions
   end
 
   def site_admin_user_abilities
@@ -71,6 +75,7 @@ class Ability
 
     can %i[create], [Upload], organization: { id: member_organization_ids }
     can :read, AllowlistedJwt, resource_type: 'Organization', resource_id: member_organization_ids
+    organization_ability_restrictions({ id: member_organization_ids })
   end
 
   def member_organization_ids

--- a/app/models/token_ability.rb
+++ b/app/models/token_ability.rb
@@ -46,8 +46,14 @@ class TokenAbility
 
   def token_download_abilities
     can :read, Organization
-    can :read, [Stream, Upload]
-    can :read, ActiveStorage::Attachment
+
+    organization_ability_restrictions
+    organization_ability_restrictions({ allowlisted_jwts: { jti: token_jti } })
+  end
+
+  def organization_ability_restrictions(restrictions = { restrict_downloads: false })
+    can :read, [Stream, Upload], organization: restrictions
+    can :read, ActiveStorage::Attachment, { record: { organization: restrictions } }
   end
 
   def token_jti

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -5,6 +5,9 @@
 <%= contact_form.email_field :email, label: 'POD contact for this organization', help: 'An email address other POD users can use to contact this organization.' %>
 <% end %>
 <%= form.check_box :provider if organization.new_record? %>
+<% if current_user.has_role?(:admin) || current_user.has_role?(:superadmin) %>
+  <%= form.check_box :restrict_downloads, label: 'Restrict downloads to organization members only', checked: organization.restrict_downloads %>
+<% end %>
 <div class="mb-3">
   <%= render IconLabelComponent.new(icon: organization&.icon) %>
   <%= form.file_field_without_bootstrap :icon, type: :file, direct_upload: true, id: 'customFile', class: 'form-control', accept: '.svg, .png, .jpg, .jpeg' %>

--- a/app/views/streams/_header.html.erb
+++ b/app/views/streams/_header.html.erb
@@ -1,5 +1,10 @@
 <div class="d-flex align-items-center">
-  <h2 class="font-weight-normal mb-0">Stream: <%= stream.display_name %></h2>
+  <h2 class="font-weight-normal mb-0">
+    <% if stream.organization.restrict_downloads %>
+      <i class="bi bi-lock-fill text-warning" title="Downloads are restricted to organization members only"></i>
+    <% end %>
+    Stream: <%= stream.display_name %>
+  </h2>
 
   <div class="p-2">
     <%= render StreamBadgeComponent.new(stream: stream) %>

--- a/db/migrate/20251113152232_add_restrict_downloads_to_organizations.rb
+++ b/db/migrate/20251113152232_add_restrict_downloads_to_organizations.rb
@@ -1,0 +1,15 @@
+class AddRestrictDownloadsToOrganizations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :organizations, :restrict_downloads, :boolean, default: true, null: false
+
+    reversible do |dir|
+      dir.up do
+        Organization.reset_column_information
+
+        Organization.providers.find_each do |organization|
+          organization.update(restrict_downloads: false)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_11_200425) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_13_152232) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -242,6 +242,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_11_200425) do
     t.string "name"
     t.json "normalization_steps"
     t.boolean "provider", default: true
+    t.boolean "restrict_downloads", default: true, null: false
     t.string "slug"
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_organizations_on_slug", unique: true

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     trait :consumer do
       provider { false }
     end
+
+    trait :unrestricted do
+      restrict_downloads { false }
+    end
   end
 end

--- a/spec/features/normalized_download_spec.rb
+++ b/spec/features/normalized_download_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Downloading normalized files from POD' do
-  let(:organization) { create(:organization, code: 'best-org') }
+  let(:organization) { create(:organization, :unrestricted, code: 'best-org') }
   let(:stream) { create(:stream, organization: organization, status: 'default') }
   let(:user) { create(:user) }
 

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'OAI-PMH' do
-  let(:organization) { create(:organization, name: 'My Org', slug: 'my-org') }
+  let(:organization) { create(:organization, :unrestricted, name: 'My Org', slug: 'my-org') }
   let(:user) { create(:user) }
 
   # NOTE: capybara matchers don't always seem to work on returned XML documents;

--- a/spec/features/streams_spec.rb
+++ b/spec/features/streams_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'uploading files to POD' do
         GenerateFullDumpJob.perform_now(organization.default_stream)
       end
 
+      user.add_role :member, organization
       user.add_role :owner, organization
       login_as(user, scope: :user)
     end

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'uploading files to POD' do
     let(:user) { create(:user) }
 
     before do
+      user.add_role :member, organization
       user.add_role :owner, organization
       login_as(user, scope: :user)
     end

--- a/spec/views/organizations/new.html.erb_spec.rb
+++ b/spec/views/organizations/new.html.erb_spec.rb
@@ -3,7 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'organizations/new' do
+  let(:current_user) { create(:user) }
+
   before do
+    allow(view).to receive(:current_user).and_return(current_user)
     assign(:organization, Organization.new(
                             name: 'MyString',
                             slug: 'MyString'

--- a/spec/views/organizations/organization_details.html.erb_spec.rb
+++ b/spec/views/organizations/organization_details.html.erb_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe 'organizations/organization_details' do
   let(:organization) { create(:organization, name: 'Best University') }
   let(:contact_email) { create(:contact_email, organization: organization) }
+  let(:current_user) { create(:user) }
 
   before do
     assign(:organization, organization)
     assign(:contact_email, contact_email)
+    allow(view).to receive(:current_user).and_return(current_user)
   end
 
   # rubocop:disable RSpec/ExampleLength


### PR DESCRIPTION
Part of #1291 

Another step toward organization controlled download restrictions. Tom wants the default to be restricted so that's what I've done, but to maintain the current behavior for existing organizations I flip this to unrestricted in the initial migration. I added a control in the UI for POD site admins to change this restriction setting. We will likely want to open this up to org owners once more fine-grained access controls are added.