### PR TITLE
Leave current default stream set as the default while the new stream is pending

### DIFF
--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -44,11 +44,7 @@ class Stream < ApplicationRecord
   def make_pending
     return if pending?
 
-    Stream.transaction do
-      organization.streams.default.each { |stream| stream.update(status: 'active') }
-      update(status: 'pending')
-    end
-
+    update(status: 'pending')
     PromoteStreamToDefaultJob.perform_later(self)
   end
 


### PR DESCRIPTION


Fixes #1479