### PR TITLE
Add feature flagged UI controls to manage record access

### DIFF
--- a/app/components/downloaders/access_form_component.html.erb
+++ b/app/components/downloaders/access_form_component.html.erb
@@ -1,0 +1,37 @@
+<div class="col-12 col-lg-6">
+  <%= heading %>
+  <%= description %>
+  <table class="table table-striped mb-3">
+    <thead>
+      <tr>
+        <th><span class="visually-hidden">Icon</span></th>
+        <th><%= resource_type %></th>
+        <th><%= t('downloaders.access_form_component.table_header.grant_access') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @resources.each do |resource| %>
+        <tr>
+          <td class="align-middle text-center icon-column">
+            <% if resource.icon.attached? %>
+              <%= link_to image_tag(resource.icon, alt: '', class: 'icon-sm'), resource, aria: { hidden: true } %>
+            <% end %>
+          </td>
+          <td><%= link_to resource_name(resource), resource %></td>
+          <td class="align-middle text-center">
+            <turbo-frame id="<%= dom_id(resource, :access) %>">
+              <div class="form-check align-middle d-inline-block">
+                <% if access_granted?(resource) %>
+                  <%= revoke_download_access_link(resource) %>
+                  <input class="form-check-input pe-none" type="checkbox" aria-label="Access granted?" checked>
+                <% else %>
+                  <%= grant_download_access_link(resource) %>
+                <% end %>
+              </div>
+            </turbo-frame>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/components/downloaders/access_form_component.rb
+++ b/app/components/downloaders/access_form_component.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Downloaders
+  # Component for rendering a table to manage download access for organizations and groups
+  class AccessFormComponent < ViewComponent::Base
+    def initialize(organization:, resources:, resource_type:)
+      super()
+      @organization = organization
+      @resources = resources
+      @resource_type = resource_type
+    end
+
+    attr_reader :resource_type
+
+    def render?
+      @resources.any? && helpers.can?(:control_access, @organization)
+    end
+
+    def heading
+      tag.h5 I18n.t("downloaders.access_form_component.#{resource_type.downcase}.heading")
+    end
+
+    def description
+      tag.p I18n.t("downloaders.access_form_component.#{resource_type.downcase}.description_html",
+                   org_name: @organization.name), safe: true
+    end
+
+    def access_granted?(resource)
+      @organization.downloader_groups.include?(resource) ||
+        @organization.downloader_organizations.include?(resource)
+    end
+
+    def revoke_download_access_link(resource)
+      downloader = @organization.downloaders.find_by(resource: resource)
+      tag.a '',
+            href: helpers.organization_downloader_path(@organization, downloader),
+            data: { turbo_method: :delete,
+                    turbo_confirm: I18n.t('downloaders.access_form_component.confirm_remove',
+                                          consumer: resource_name(resource), provider: @organization.name) },
+            class: 'form-check-input checked',
+            title: I18n.t('downloaders.access_form_component.revoke_access')
+    end
+
+    def grant_download_access_link(resource)
+      tag.a '',
+            href: helpers.organization_downloaders_path(@organization, resource_type: resource_type, resource_id: resource.id),
+            data: { turbo_method: :post,
+                    turbo_confirm: I18n.t('downloaders.access_form_component.confirm_add',
+                                          consumer: resource_name(resource), provider: @organization.name) },
+            class: 'form-check-input',
+            title: I18n.t('downloaders.access_form_component.grant_access')
+    end
+
+    def resource_name(resource)
+      resource.respond_to?(:display_name) ? resource.display_name : resource.name
+    end
+  end
+end

--- a/app/components/downloaders/administer_access_component.html.erb
+++ b/app/components/downloaders/administer_access_component.html.erb
@@ -1,0 +1,16 @@
+<h4 class="mt-4"><%= t('downloaders.administer_access_component.heading') %></h4>
+<% unless @organization.restrict_downloads %>
+  <div class="alert alert-warning" role="alert">
+    <%= t('downloaders.administer_access_component.unrestricted_alert') %>
+  </div>
+<% end %>
+<div class="container mt-4">
+  <div class="row">
+    <%= render Downloaders::AccessFormComponent.new(organization: @organization,
+                                                    resources: @groups,
+                                                    resource_type: 'Group') %>
+    <%= render Downloaders::AccessFormComponent.new(organization: @organization,
+                                                    resources: @other_organizations,
+                                                    resource_type: 'Organization') %>
+  </div>
+</div>

--- a/app/components/downloaders/administer_access_component.rb
+++ b/app/components/downloaders/administer_access_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Downloaders
+  # Component for rendering controls related to administering download access
+  # for organizations and groups
+  class AdministerAccessComponent < ViewComponent::Base
+    def initialize(organization:, groups:, other_organizations:)
+      super()
+      @organization = organization
+      @groups = groups
+      @other_organizations = other_organizations
+    end
+
+    def render?
+      helpers.can?(:control_access, @organization)
+    end
+  end
+end

--- a/app/components/downloaders/restrict_downloads_form_component.html.erb
+++ b/app/components/downloaders/restrict_downloads_form_component.html.erb
@@ -1,0 +1,13 @@
+<%= helpers.bootstrap_form_with(model: @organization, url: organization_path(@organization), html: { method: :patch }) do |f| %>
+  <div class="mb-3">
+    <%= f.select :restrict_downloads, options_for_select([[t('downloaders.restrict_downloads_form_component.unrestricted_option'), false],
+                                                          [t('downloaders.restrict_downloads_form_component.restricted_option'), true]],
+                                                          @organization.restrict_downloads), class: 'form-select' %>
+    <div class="form-text">
+      <%= t('downloaders.restrict_downloads_form_component.form_text') %>
+    </div>
+  </div>
+  <div class="mb-3">
+    <%= f.submit t('downloaders.restrict_downloads_form_component.submit_button'), class: 'btn btn-danger' %>
+  </div>
+<% end %>

--- a/app/components/downloaders/restrict_downloads_form_component.rb
+++ b/app/components/downloaders/restrict_downloads_form_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Downloaders
+  # Component for rendering a form that sets whether an organization's download access
+  # is unrestricted or restricted to certain groups and organizations.
+  class RestrictDownloadsFormComponent < ViewComponent::Base
+    def initialize(organization:)
+      super()
+      @organization = organization
+    end
+
+    def render?
+      helpers.can?(:control_access, @organization)
+    end
+  end
+end

--- a/app/controllers/downloaders_controller.rb
+++ b/app/controllers/downloaders_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Controller for managing permitted downloaders (organizations and groups) for an organization
+class DownloadersController < ApplicationController
+  load_and_authorize_resource :organization
+  load_and_authorize_resource through: :organization
+
+  def index
+    @other_organizations = Organization.accessible_by(current_ability).where.not(id: @organization.id)
+    @groups = Group.accessible_by(current_ability)
+  end
+
+  def create
+    authorize! :control_access, @organization
+
+    Downloader.find_or_create_by(create_downloader_params)
+    redirect_to organization_downloaders_path(@organization),
+                notice: I18n.t('downloaders.create.success')
+  end
+
+  def destroy
+    authorize! :control_access, @organization
+
+    @downloader.destroy
+    redirect_to organization_downloaders_path(@organization),
+                notice: I18n.t('downloaders.destroy.success')
+  end
+
+  private
+
+  def create_downloader_params
+    params.permit(:resource_type, :resource_id).merge(organization: @organization)
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,6 +28,8 @@ class Ability
 
   def all_user_abilities
     can :read, Organization
+    can :read, Downloader
+    can :read, Group
     can :read, :dashboard
   end
 
@@ -67,6 +69,7 @@ class Ability
   def organization_owner_abilities
     return if owned_organization_ids.empty?
 
+    can :control_access, Organization, id: owned_organization_ids if Settings.allow_organization_owners_to_manage_access
     can %i[edit administer invite], Organization, id: owned_organization_ids
     can %i[create update], Stream, organization: { id: owned_organization_ids }
     can :destroy, Stream, organization: { id: owned_organization_ids }, status: Stream::STATUSES - %w[default previous-default]

--- a/app/views/downloaders/index.html.erb
+++ b/app/views/downloaders/index.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/layout_manage_organization' do %>
+  <h3><%= t('downloaders.index.heading') %></h3>
+  <%= render Downloaders::RestrictDownloadsFormComponent.new(organization: @organization) %>
+  <%= render Downloaders::AdministerAccessComponent.new(organization: @organization, groups: @groups, other_organizations: @other_organizations) %>
+<% end %>

--- a/app/views/shared/_manage_organization_header.html.erb
+++ b/app/views/shared/_manage_organization_header.html.erb
@@ -17,5 +17,8 @@
     <% if @organization.provider? %>
       <%= link_to "Provider details", provider_details_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(provider_details_organization_path(@organization))}" %>
     <% end %>
+    <% if @organization.provider? && can?(:control_access, @organization) %>
+      <%= link_to "Access restrictions", organization_downloaders_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_downloaders_path(@organization))}" %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,34 @@ en:
       provider: Provider
       total_records: Total records
     title: Recent activity
+  downloaders:
+    access_form_component:
+      confirm_add: Allow %{consumer} to download %{provider}'s records?
+      confirm_remove: Revoke %{consumer}'s access to download %{provider}'s records?
+      grant_access: Grant access
+      group:
+        description_html: Granting group access allows all member organizations of the group to download records from %{org_name}, regardless of their individual access settings.
+        heading: Manage group access
+      organization:
+        description_html: Granting organization access allows that specific organization to download records from %{org_name}. Group access takes precedence.
+        heading: Manage organization access
+      revoke_access: Revoke access
+      table_header:
+        grant_access: Grant access?
+    administer_access_component:
+      heading: Manage access
+      unrestricted_alert: Access is currently unrestricted. Enable download restrictions to enforce access settings.
+    create:
+      success: Access was successfully granted.
+    destroy:
+      success: Access was successfully revoked.
+    index:
+      heading: Access restrictions
+    restrict_downloads_form_component:
+      form_text: Choose whether to allow any POD organization to download records from your organization, or restrict access to specific organizations and groups.
+      restricted_option: Restricted - Only allow specific organizations and groups to download records
+      submit_button: Update download access policy
+      unrestricted_option: Unrestricted - Allow any POD organization to download records
   groups:
     create:
       success: Group was successfully created.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
 
     # Route in the Manage Organization / View Organization Details tabs
     resources :organization_users, as: 'users', only: [:index, :destroy, :update], path: 'users'
+    resources :downloaders, only: [:index, :create, :destroy]
     resources :allowlisted_jwts, only: [:index, :new, :create, :destroy]
 
     resource :organization_contact_email, as: 'contact_email', only: [:new, :create, :destroy]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,8 @@ action_mailer:
 contact_email: 'pod-support@lists.stanford.edu'
 accessibility_email: 'library-accessibility-contact@lists.stanford.edu'
 
+allow_organization_owners_to_manage_access: false
+
 marc_fixture_seeds:
   host: https://pod.stanford.edu
   token: ''

--- a/spec/components/downloaders/administer_access_component_spec.rb
+++ b/spec/components/downloaders/administer_access_component_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Downloaders::AdministerAccessComponent, type: :component do
+  subject(:rendered) do
+    Capybara::Node::Simple.new(render_inline(described_class.new(organization: organization, groups: groups,
+                                                                 other_organizations: other_organizations)).to_html)
+  end
+
+  let(:organization) { create(:organization) }
+  let(:groups) { create_list(:group, 2) }
+  let(:other_organizations) { [] }
+  let(:admin_user) { create(:admin) }
+
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ApplicationController).to receive(:current_ability).and_return(Ability.new(admin_user))
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  it 'renders the administer access controls' do # rubocop:disable RSpec/MultipleExpectations
+    expect(rendered).to have_css('h4', text: 'Manage access')
+    expect(rendered).to have_css('h5', text: 'Manage group access')
+    expect(rendered).to have_css('.form-check-input', count: 2)
+  end
+end

--- a/spec/components/downloaders/restrict_downloads_form_component_spec.rb
+++ b/spec/components/downloaders/restrict_downloads_form_component_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Downloaders::RestrictDownloadsFormComponent, type: :component do
+  subject(:rendered) do
+    Capybara::Node::Simple.new(render_inline(described_class.new(organization: organization)).to_html)
+  end
+
+  let(:organization) { create(:organization) }
+  let(:admin_user) { create(:admin) }
+
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ApplicationController).to receive(:current_ability).and_return(Ability.new(admin_user))
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  it 'renders the restrict downloads form' do # rubocop:disable RSpec/MultipleExpectations
+    expect(rendered).to have_css('label', text: 'Restrict downloads')
+    expect(rendered).to have_css('option', text: 'Unrestricted')
+    expect(rendered).to have_css('option', text: 'Restricted')
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -31,10 +31,13 @@ RSpec.describe Ability do
       let(:user) { User.new }
 
       it { is_expected.to be_able_to(:read, create(:organization)) }
+      it { is_expected.to be_able_to(:read, Downloader.new) }
+      it { is_expected.to be_able_to(:read, Group.new) }
       it { is_expected.not_to be_able_to(:read, Upload.new) }
       it { is_expected.not_to be_able_to(:read, Stream.new) }
       it { is_expected.not_to be_able_to(:read, AllowlistedJwt.new) }
       it { is_expected.not_to be_able_to(:destroy, default_stream) }
+      it { is_expected.not_to be_able_to(:control_access, organization) }
     end
 
     context 'with an owner of an org' do
@@ -43,6 +46,7 @@ RSpec.describe Ability do
       before do
         user.add_role :member, organization # Owners are also members
         user.add_role :owner, organization
+        allow(Settings).to receive(:allow_organization_owners_to_manage_access).and_return(true)
       end
 
       it { is_expected.not_to be_able_to(:destroy, default_stream) }
@@ -50,6 +54,7 @@ RSpec.describe Ability do
 
       # Owner organization
       it { is_expected.to be_able_to(%i[edit administer], organization) }
+      it { is_expected.to be_able_to(:control_access, organization) }
 
       it { is_expected.not_to be_able_to(:destroy, organization) }
 
@@ -92,6 +97,7 @@ RSpec.describe Ability do
       # Member organization
       it { is_expected.not_to be_able_to(:manage, organization) }
       it { is_expected.to be_able_to(:read, organization) }
+      it { is_expected.not_to be_able_to(:control_access, organization) }
 
       it { is_expected.to be_able_to(:read, Upload.new(organization: organization)) }
       it { is_expected.to be_able_to(:create, Upload.new(organization: organization)) }

--- a/spec/routing/downloaders_controller_spec.rb
+++ b/spec/routing/downloaders_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'routes for DownloadersController' do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/organizations/1/downloaders').to route_to(
+        'downloaders#index', organization_id: '1'
+      )
+    end
+
+    it 'routes to #create' do
+      expect(post: '/organizations/1/downloaders').to route_to(
+        'downloaders#create', organization_id: '1'
+      )
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/organizations/1/downloaders/2').to route_to(
+        'downloaders#destroy', organization_id: '1', id: '2'
+      )
+    end
+  end
+end

--- a/spec/views/downloaders/index.html.erb_spec.rb
+++ b/spec/views/downloaders/index.html.erb_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'downloaders/index' do
+  let(:organization) { create(:organization) }
+  let(:owner) { create(:user) }
+
+  before do
+    owner.add_role :owner, organization
+    assign(:organization, organization)
+    assign(:other_organizations, create_list(:organization, 2))
+    assign(:groups, create_list(:group, 2))
+  end
+
+  it 'renders a heading' do
+    render
+    expect(rendered).to have_css('h3', text: 'Access restrictions')
+  end
+
+  context 'when the user is an owner' do
+    before do
+      allow(Settings).to receive(:allow_organization_owners_to_manage_access).and_return(true)
+      sign_in owner
+      render
+    end
+
+    it 'renders a submit button to update access restrictions' do
+      expect(rendered).to have_button('Update download access policy')
+    end
+
+    it 'renders a component to manage group access' do
+      expect(rendered).to have_css('h5', text: 'Manage group access')
+    end
+
+    it 'renders a component to manage organization access' do
+      expect(rendered).to have_css('h5', text: 'Manage organization access')
+    end
+  end
+end

--- a/spec/views/shared/manage_organization_header.html.erb_spec.rb
+++ b/spec/views/shared/manage_organization_header.html.erb_spec.rb
@@ -20,10 +20,18 @@ RSpec.describe 'shared/_manage_organization_header' do
   end
   # rubocop:enable RSpec/MultipleExpectations
 
-  it 'displays the Access tokens link for priveleged users' do
-    allow(view).to receive(:can?).and_return(true)
-    render
+  context 'when user has priveleges' do
+    before do
+      allow(view).to receive(:can?).and_return(true)
+      render
+    end
 
-    expect(rendered).to have_link('Access tokens')
+    it 'displays the Access tokens link' do
+      expect(rendered).to have_link('Access tokens')
+    end
+
+    it 'displays the access restrictions link' do
+      expect(rendered).to have_link('Access restrictions')
+    end
   end
 end


### PR DESCRIPTION
Part of #1291 

This adds forms for controlling download/record access settings for organizations. I've added a new `:control_access` ability so we can feature flag this ability (which we can probably eventually remove in favor of `:administer`). By default only POD site admins will be able to view or submit these forms. I plan to add some additional UI niceties for displaying info to non-admins and a summary table about who can access, but that will come other pull requests. Getting this in will let us set up access for each organization the way we want before restricting access and before letting organization owners control this. So...this isn't quite all the way there, but good enough to deploy to prod I think.

<img width="1173" height="1112" alt="Screenshot 2025-11-17 at 4 16 57 PM" src="https://github.com/user-attachments/assets/4c1d1c74-47fc-4d87-bcc3-0e822c12fe71" />
