### PR TITLE
Allow non site admins to view current access settings

### DIFF
--- a/app/components/downloaders/access_checkbox_component.html.erb
+++ b/app/components/downloaders/access_checkbox_component.html.erb
@@ -1,0 +1,5 @@
+<turbo-frame id="<%= helpers.dom_id(@resource, :access) %>">
+  <div class="form-check align-middle d-inline-block">
+    <%= access_display %>
+  </div>
+</turbo-frame>

--- a/app/components/downloaders/access_checkbox_component.rb
+++ b/app/components/downloaders/access_checkbox_component.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Downloaders
+  # Component for rendering a checkbox to manage download access for a resource
+  class AccessCheckboxComponent < ViewComponent::Base
+    def initialize(organization:, resource:)
+      super()
+      @organization = organization
+      @resource = resource
+    end
+
+    def access_display
+      helpers.can?(:control_access, @organization) && @organization.restrict_downloads ? access_link : icon
+    end
+
+    private
+
+    def icon
+      StatusIcons::DownloadAccessIconComponent.new(status: icon_status).call
+    end
+
+    def icon_status
+      !@organization.restrict_downloads || access_granted? ? 'can_access' : 'cannot_access'
+    end
+
+    def access_link
+      if access_granted?
+        revoke_download_access_link + checkbox_input
+      else
+        grant_download_access_link
+      end
+    end
+
+    def access_granted?
+      @organization.downloader_groups.include?(@resource) ||
+        @organization.downloader_organizations.include?(@resource)
+    end
+
+    def checkbox_input
+      tag.input type: 'checkbox', class: 'form-check-input pe-none', aria: { label: 'Access granted?' }, checked: 'checked'
+    end
+
+    def revoke_download_access_link
+      downloader = @organization.downloaders.find_by(resource: @resource)
+      tag.a '',
+            href: helpers.organization_downloader_path(@organization, downloader),
+            data: { turbo_method: :delete,
+                    turbo_confirm: I18n.t('downloaders.access_form_component.confirm_remove',
+                                          consumer: resource_name, provider: @organization.name) },
+            class: 'form-check-input checked',
+            title: I18n.t('downloaders.access_form_component.revoke_access')
+    end
+
+    def grant_download_access_link
+      tag.a '',
+            href: helpers.organization_downloaders_path(@organization, resource_type: @resource.class.name,
+                                                                       resource_id: @resource.id),
+            data: { turbo_method: :post,
+                    turbo_confirm: I18n.t('downloaders.access_form_component.confirm_add',
+                                          consumer: resource_name, provider: @organization.name) },
+            class: 'form-check-input',
+            title: I18n.t('downloaders.access_form_component.grant_access')
+    end
+
+    def resource_name
+      @resource.respond_to?(:display_name) ? @resource.display_name : @resource.name
+    end
+  end
+end

--- a/app/components/downloaders/access_form_component.html.erb
+++ b/app/components/downloaders/access_form_component.html.erb
@@ -6,7 +6,7 @@
       <tr>
         <th><span class="visually-hidden">Icon</span></th>
         <th><%= resource_type %></th>
-        <th><%= t('downloaders.access_form_component.table_header.grant_access') %></th>
+        <th class="text-start"><%= t('downloaders.access_form_component.table_header.grant_access') %></th>
       </tr>
     </thead>
     <tbody>
@@ -18,17 +18,8 @@
             <% end %>
           </td>
           <td><%= link_to resource_name(resource), resource %></td>
-          <td class="align-middle text-center">
-            <turbo-frame id="<%= dom_id(resource, :access) %>">
-              <div class="form-check align-middle d-inline-block">
-                <% if access_granted?(resource) %>
-                  <%= revoke_download_access_link(resource) %>
-                  <input class="form-check-input pe-none" type="checkbox" aria-label="Access granted?" checked>
-                <% else %>
-                  <%= grant_download_access_link(resource) %>
-                <% end %>
-              </div>
-            </turbo-frame>
+          <td class="align-middle text-start">
+            <%= render Downloaders::AccessCheckboxComponent.new(organization: @organization, resource: resource) %>
           </td>
         </tr>
       <% end %>

--- a/app/components/downloaders/access_form_component.rb
+++ b/app/components/downloaders/access_form_component.rb
@@ -13,7 +13,7 @@ module Downloaders
     attr_reader :resource_type
 
     def render?
-      @resources.any? && helpers.can?(:control_access, @organization)
+      @resources.any?
     end
 
     def heading
@@ -23,32 +23,6 @@ module Downloaders
     def description
       tag.p I18n.t("downloaders.access_form_component.#{resource_type.downcase}.description_html",
                    org_name: @organization.name), safe: true
-    end
-
-    def access_granted?(resource)
-      @organization.downloader_groups.include?(resource) ||
-        @organization.downloader_organizations.include?(resource)
-    end
-
-    def revoke_download_access_link(resource)
-      downloader = @organization.downloaders.find_by(resource: resource)
-      tag.a '',
-            href: helpers.organization_downloader_path(@organization, downloader),
-            data: { turbo_method: :delete,
-                    turbo_confirm: I18n.t('downloaders.access_form_component.confirm_remove',
-                                          consumer: resource_name(resource), provider: @organization.name) },
-            class: 'form-check-input checked',
-            title: I18n.t('downloaders.access_form_component.revoke_access')
-    end
-
-    def grant_download_access_link(resource)
-      tag.a '',
-            href: helpers.organization_downloaders_path(@organization, resource_type: resource_type, resource_id: resource.id),
-            data: { turbo_method: :post,
-                    turbo_confirm: I18n.t('downloaders.access_form_component.confirm_add',
-                                          consumer: resource_name(resource), provider: @organization.name) },
-            class: 'form-check-input',
-            title: I18n.t('downloaders.access_form_component.grant_access')
     end
 
     def resource_name(resource)

--- a/app/components/downloaders/administer_access_component.html.erb
+++ b/app/components/downloaders/administer_access_component.html.erb
@@ -1,16 +1,11 @@
 <h4 class="mt-4"><%= t('downloaders.administer_access_component.heading') %></h4>
-<% unless @organization.restrict_downloads %>
-  <div class="alert alert-warning" role="alert">
-    <%= t('downloaders.administer_access_component.unrestricted_alert') %>
-  </div>
-<% end %>
 <div class="container mt-4">
   <div class="row">
     <%= render Downloaders::AccessFormComponent.new(organization: @organization,
-                                                    resources: @groups,
+                                                    resources: groups,
                                                     resource_type: 'Group') %>
     <%= render Downloaders::AccessFormComponent.new(organization: @organization,
-                                                    resources: @other_organizations,
+                                                    resources: other_organizations,
                                                     resource_type: 'Organization') %>
   </div>
 </div>

--- a/app/components/downloaders/administer_access_component.rb
+++ b/app/components/downloaders/administer_access_component.rb
@@ -4,15 +4,17 @@ module Downloaders
   # Component for rendering controls related to administering download access
   # for organizations and groups
   class AdministerAccessComponent < ViewComponent::Base
-    def initialize(organization:, groups:, other_organizations:)
+    def initialize(organization:)
       super()
       @organization = organization
-      @groups = groups
-      @other_organizations = other_organizations
     end
 
-    def render?
-      helpers.can?(:control_access, @organization)
+    def groups
+      @groups ||= Group.accessible_by(helpers.current_ability)
+    end
+
+    def other_organizations
+      @other_organizations ||= Organization.accessible_by(helpers.current_ability).where.not(id: @organization.id)
     end
   end
 end

--- a/app/components/status_icons/download_access_icon_component.rb
+++ b/app/components/status_icons/download_access_icon_component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module StatusIcons
+  # Download access status icon component
+  class DownloadAccessIconComponent < StatusIconComponent
+    def settings_data
+      Settings.download_access_status
+    end
+  end
+end

--- a/app/controllers/downloaders_controller.rb
+++ b/app/controllers/downloaders_controller.rb
@@ -5,10 +5,7 @@ class DownloadersController < ApplicationController
   load_and_authorize_resource :organization
   load_and_authorize_resource through: :organization
 
-  def index
-    @other_organizations = Organization.accessible_by(current_ability).where.not(id: @organization.id)
-    @groups = Group.accessible_by(current_ability)
-  end
+  def index; end
 
   def create
     authorize! :control_access, @organization

--- a/app/views/downloaders/index.html.erb
+++ b/app/views/downloaders/index.html.erb
@@ -1,5 +1,5 @@
 <%= render 'shared/layout_manage_organization' do %>
   <h3><%= t('downloaders.index.heading') %></h3>
   <%= render Downloaders::RestrictDownloadsFormComponent.new(organization: @organization) %>
-  <%= render Downloaders::AdministerAccessComponent.new(organization: @organization, groups: @groups, other_organizations: @other_organizations) %>
+  <%= render Downloaders::AdministerAccessComponent.new(organization: @organization) %>
 <% end %>

--- a/app/views/shared/_manage_organization_header.html.erb
+++ b/app/views/shared/_manage_organization_header.html.erb
@@ -16,8 +16,6 @@
     <%= link_to "Organization details", organization_details_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_details_organization_path(@organization))}" %>
     <% if @organization.provider? %>
       <%= link_to "Provider details", provider_details_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(provider_details_organization_path(@organization))}" %>
-    <% end %>
-    <% if @organization.provider? && can?(:control_access, @organization) %>
       <%= link_to "Access restrictions", organization_downloaders_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_downloaders_path(@organization))}" %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,16 +21,15 @@ en:
       grant_access: Grant access
       group:
         description_html: Granting group access allows all member organizations of the group to download records from %{org_name}, regardless of their individual access settings.
-        heading: Manage group access
+        heading: Group access
       organization:
         description_html: Granting organization access allows that specific organization to download records from %{org_name}. Group access takes precedence.
-        heading: Manage organization access
+        heading: Organization access
       revoke_access: Revoke access
       table_header:
-        grant_access: Grant access?
+        grant_access: Access granted?
     administer_access_component:
-      heading: Manage access
-      unrestricted_alert: Access is currently unrestricted. Enable download restrictions to enforce access settings.
+      heading: Access settings
     create:
       success: Access was successfully granted.
     destroy:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,6 +70,14 @@ upload_status:
     icon_class: 'bi bi-question-circle-fill align-middle text-info'
     label: 'Unknown'
 
+download_access_status:
+  can_access:
+    icon_class: 'bi bi-check-circle-fill text-success'
+    label: 'Can download records'
+  cannot_access:
+    icon_class: 'bi bi-dash'
+    label: 'Cannot download records'
+
 # max. MARC records per OAI-XML file; also max. size of one page in ListRecords
 oai_max_page_size: 5000
 

--- a/spec/components/downloaders/administer_access_component_spec.rb
+++ b/spec/components/downloaders/administer_access_component_spec.rb
@@ -4,24 +4,32 @@ require 'rails_helper'
 
 RSpec.describe Downloaders::AdministerAccessComponent, type: :component do
   subject(:rendered) do
-    Capybara::Node::Simple.new(render_inline(described_class.new(organization: organization, groups: groups,
-                                                                 other_organizations: other_organizations)).to_html)
+    Capybara::Node::Simple.new(render_inline(described_class.new(organization: organization)).to_html)
   end
 
   let(:organization) { create(:organization) }
-  let(:groups) { create_list(:group, 2) }
   let(:other_organizations) { [] }
-  let(:admin_user) { create(:admin) }
+  let(:user) { create(:admin) }
 
   before do
     # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(ApplicationController).to receive(:current_ability).and_return(Ability.new(admin_user))
+    allow_any_instance_of(ApplicationController).to receive(:current_ability).and_return(Ability.new(user))
     # rubocop:enable RSpec/AnyInstance
+    Group.create!(name: 'Group A')
   end
 
   it 'renders the administer access controls' do # rubocop:disable RSpec/MultipleExpectations
-    expect(rendered).to have_css('h4', text: 'Manage access')
-    expect(rendered).to have_css('h5', text: 'Manage group access')
-    expect(rendered).to have_css('.form-check-input', count: 2)
+    expect(rendered).to have_css('h4', text: 'Access settings')
+    expect(rendered).to have_css('h5', text: 'Group access')
+    expect(rendered).to have_css('.form-check-input', count: 1)
+  end
+
+  context 'when the user is not an admin' do
+    let(:user) { create(:user) }
+
+    it 'only renders a status icon and not a checkbox' do
+      expect(rendered).to have_no_css('.form-check-input')
+      expect(rendered).to have_css('i', class: 'bi bi-dash cannot_access')
+    end
   end
 end

--- a/spec/views/downloaders/index.html.erb_spec.rb
+++ b/spec/views/downloaders/index.html.erb_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe 'downloaders/index' do
     end
 
     it 'renders a component to manage group access' do
-      expect(rendered).to have_css('h5', text: 'Manage group access')
+      expect(rendered).to have_css('h5', text: 'Group access')
     end
 
     it 'renders a component to manage organization access' do
-      expect(rendered).to have_css('h5', text: 'Manage organization access')
+      expect(rendered).to have_css('h5', text: 'Organization access')
     end
   end
 end


### PR DESCRIPTION
Part of #1291 

Adds a view of the current access settings for non-admins:

<img width="1158" height="846" alt="Screenshot 2025-11-19 at 1 19 14 PM" src="https://github.com/user-attachments/assets/5579875f-f363-4071-ba10-5de9cb9a05a2" />
