### PR TITLE
Alias Organization.name to display_name

### DIFF
--- a/app/components/downloaders/access_checkbox_component.rb
+++ b/app/components/downloaders/access_checkbox_component.rb
@@ -46,7 +46,7 @@ module Downloaders
             href: helpers.organization_downloader_path(@organization, downloader),
             data: { turbo_method: :delete,
                     turbo_confirm: I18n.t('downloaders.access_form_component.confirm_remove',
-                                          consumer: resource_name, provider: @organization.name) },
+                                          consumer: @resource.display_name, provider: @organization.name) },
             class: 'form-check-input checked',
             title: I18n.t('downloaders.access_form_component.revoke_access')
     end
@@ -57,13 +57,9 @@ module Downloaders
                                                                        resource_id: @resource.id),
             data: { turbo_method: :post,
                     turbo_confirm: I18n.t('downloaders.access_form_component.confirm_add',
-                                          consumer: resource_name, provider: @organization.name) },
+                                          consumer: @resource.display_name, provider: @organization.name) },
             class: 'form-check-input',
             title: I18n.t('downloaders.access_form_component.grant_access')
-    end
-
-    def resource_name
-      @resource.respond_to?(:display_name) ? @resource.display_name : @resource.name
     end
   end
 end

--- a/app/components/downloaders/access_form_component.html.erb
+++ b/app/components/downloaders/access_form_component.html.erb
@@ -17,7 +17,7 @@
               <%= link_to image_tag(resource.icon, alt: '', class: 'icon-sm'), resource, aria: { hidden: true } %>
             <% end %>
           </td>
-          <td><%= link_to resource_name(resource), resource %></td>
+          <td><%= link_to resource.display_name, resource %></td>
           <td class="align-middle text-start">
             <%= render Downloaders::AccessCheckboxComponent.new(organization: @organization, resource: resource) %>
           </td>

--- a/app/components/downloaders/access_form_component.rb
+++ b/app/components/downloaders/access_form_component.rb
@@ -24,9 +24,5 @@ module Downloaders
       tag.p I18n.t("downloaders.access_form_component.#{resource_type.downcase}.description_html",
                    org_name: @organization.name), safe: true
     end
-
-    def resource_name(resource)
-      resource.respond_to?(:display_name) ? resource.display_name : resource.name
-    end
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -28,6 +28,9 @@ class Organization < ApplicationRecord
   scope :consumers, -> { where(provider: false) }
   validates :marc_docs_url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), allow_blank: true }
 
+  # So that Organization.display_name works like other models, such as Group
+  alias_attribute :display_name, :name
+
   def default_stream
     @default_stream ||= streams.find_or_create_by(status: 'default')
   end


### PR DESCRIPTION
When dealing with `Organization` and `Group` as resources I'd rather not have to worry about whether to call `display_name` or `name`.