### PR TITLE
Add a summary table to detail download access

### DIFF
--- a/app/components/downloaders/access_checkbox_component.html.erb
+++ b/app/components/downloaders/access_checkbox_component.html.erb
@@ -1,5 +1,3 @@
-<turbo-frame id="<%= helpers.dom_id(@resource, :access) %>">
-  <div class="form-check align-middle d-inline-block">
-    <%= access_display %>
-  </div>
-</turbo-frame>
+<div class="form-check align-middle d-inline-block">
+  <%= access_display %>
+</div>

--- a/app/components/downloaders/access_summary_table_component.html.erb
+++ b/app/components/downloaders/access_summary_table_component.html.erb
@@ -1,0 +1,19 @@
+<h4 class="mt-4"><%= t('downloaders.access_summary_table_component.heading_html') %></h4>
+<p><%= t('downloaders.access_summary_table_component.description_html', org_name: @organization.name).html_safe %></p>
+<table class="table table-striped mb-3">
+  <thead>
+    <tr>
+      <th class="visually-hidden">Icon</th>
+      <th><%= t('downloaders.access_summary_table_component.table_heading.organization') %></th>
+      <th class="text-end"><%= t('downloaders.access_summary_table_component.table_heading.access', org_name: @organization.name) %></th>
+      <th><%= t('downloaders.access_summary_table_component.table_heading.grantor_reason', org_name: @organization.name) %></th>
+      <th class="text-end"><%= t('downloaders.access_summary_table_component.table_heading.accessible', org_name: @organization.name) %></th>
+      <th><%= t('downloaders.access_summary_table_component.table_heading.grantee_reason', org_name: @organization.name) %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% other_organizations.each do |other_org| %>
+      <%= render Downloaders::AccessSummaryTableRowComponent.new(organization: @organization, other_org: other_org) %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/components/downloaders/access_summary_table_component.rb
+++ b/app/components/downloaders/access_summary_table_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Downloaders
+  # Component for rendering a table that summarizes download access for an organization.
+  class AccessSummaryTableComponent < ViewComponent::Base
+    def initialize(organization:)
+      super()
+      @organization = organization
+    end
+
+    def other_organizations
+      @other_organizations ||= Organization.accessible_by(helpers.current_ability).where.not(id: @organization.id)
+    end
+  end
+end

--- a/app/components/downloaders/access_summary_table_data_component.html.erb
+++ b/app/components/downloaders/access_summary_table_data_component.html.erb
@@ -1,0 +1,6 @@
+<td class="align-middle text-end">
+  <%= icon %>
+</td>
+<td class="align-middle">
+  <%= explanation_text %>
+</td>

--- a/app/components/downloaders/access_summary_table_data_component.rb
+++ b/app/components/downloaders/access_summary_table_data_component.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Downloaders
+  # Table data component for downloader access
+  class AccessSummaryTableDataComponent < ViewComponent::Base
+    def initialize(organization:, other_org:)
+      super()
+      @organization = organization
+      @other_org = other_org
+    end
+
+    def explanation_text # rubocop:disable Metrics/AbcSize
+      if unrestricted_access?
+        I18n.t('downloaders.access_summary_table_data_component.explanation.unrestricted_access', grantor_name: grantor_name)
+      elsif access_granted_via_group_membership? && access_granted_directly?
+        I18n.t('downloaders.access_summary_table_data_component.explanation.granted_to_org_and_group',
+               grantee_name: grantee_name,
+               groups: group_memberships_text)
+      elsif access_granted_directly?
+        I18n.t('downloaders.access_summary_table_data_component.explanation.granted_to_organization', grantee_name: grantee_name)
+      elsif access_granted_via_group_membership?
+        I18n.t('downloaders.access_summary_table_data_component.explanation.granted_through_groups',
+               grantee_name: grantee_name,
+               groups: group_memberships_text)
+      else
+        I18n.t('downloaders.access_summary_table_data_component.explanation.no_access_granted', grantee_name: grantee_name)
+      end
+    end
+
+    def icon
+      StatusIcons::DownloadAccessIconComponent.new(status: can_download? ? 'can_access' : 'cannot_access').call
+    end
+
+    private
+
+    def grantee_name
+      @other_org.name
+    end
+
+    def grantor_name
+      @organization.name
+    end
+
+    def group_memberships_text
+      (@organization.downloader_groups & @other_org.groups).map(&:display_name).to_sentence
+    end
+
+    def can_download?
+      unrestricted_access? || @other_org.effective_downloadable_organizations.include?(@organization)
+    end
+
+    def unrestricted_access?
+      !@organization.restrict_downloads
+    end
+
+    def access_granted_via_group_membership?
+      @organization.downloader_groups.intersect?(@other_org.groups)
+    end
+
+    def access_granted_directly?
+      @organization.downloader_organizations.include?(@other_org)
+    end
+  end
+end

--- a/app/components/downloaders/access_summary_table_row_component.html.erb
+++ b/app/components/downloaders/access_summary_table_row_component.html.erb
@@ -1,0 +1,10 @@
+<tr id="access_summary_table_row_<%= dom_id @other_org %>">
+  <td class="align-middle text-center icon-column">
+    <% if @other_org.icon.attached? %>
+      <%= link_to image_tag(@other_org.icon, alt: '', class: 'icon-sm'), @other_org, aria: { hidden: true } %>
+    <% end %>
+  </td>
+  <td class="align-middle"><%= link_to @other_org.name, @other_org %></td>
+  <%= render Downloaders::AccessSummaryTableDataComponent.new(organization: @organization, other_org: @other_org) %>
+  <%= render Downloaders::AccessibleSummaryTableDataComponent.new(organization: @organization, other_org: @other_org) %>
+</tr>

--- a/app/components/downloaders/access_summary_table_row_component.rb
+++ b/app/components/downloaders/access_summary_table_row_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Downloaders
+  # Component for rendering a table row that summarizes download access for an organization.
+  class AccessSummaryTableRowComponent < ViewComponent::Base
+    def initialize(organization:, other_org:)
+      super()
+      @organization = organization
+      @other_org = other_org
+    end
+  end
+end

--- a/app/components/downloaders/accessible_summary_table_data_component.rb
+++ b/app/components/downloaders/accessible_summary_table_data_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Downloaders
+  # Table data component that shows which organizations this organization can access
+  class AccessibleSummaryTableDataComponent < AccessSummaryTableDataComponent
+    def explanation_text
+      unless @other_org.provider?
+        return I18n.t('downloaders.accessible_summary_table_data_component.explanation.not_a_provider',
+                      grantor_name: grantor_name)
+      end
+
+      super
+    end
+
+    private
+
+    def grantee_name
+      @organization.name
+    end
+
+    def grantor_name
+      @other_org.name
+    end
+
+    def group_memberships_text
+      (@other_org.downloader_groups & @organization.groups).map(&:display_name).to_sentence
+    end
+
+    def can_download?
+      @other_org.provider? &&
+        (unrestricted_access? || @organization.effective_downloadable_organizations.include?(@other_org))
+    end
+
+    def unrestricted_access?
+      !@other_org.restrict_downloads
+    end
+
+    def access_granted_via_group_membership?
+      @other_org.downloader_groups.intersect?(@organization.groups)
+    end
+
+    def access_granted_directly?
+      @other_org.downloader_organizations.include?(@organization)
+    end
+  end
+end

--- a/app/views/downloaders/index.html.erb
+++ b/app/views/downloaders/index.html.erb
@@ -3,5 +3,32 @@
   <h3><%= t('downloaders.index.heading') %></h3>
   <%= render Downloaders::AccessSummaryAlertComponent.new(organization: @organization) %>
   <%= render Downloaders::RestrictDownloadsFormComponent.new(organization: @organization) %>
-  <%= render Downloaders::AdministerAccessComponent.new(organization: @organization) %>
+
+  <ul class="nav nav-tabs pt-4" id="downloaders-tabs" role="tablist">
+    <%# Manage access tab %>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="manage-tab" data-bs-toggle="tab" data-bs-target="#manage-pane" type="button"
+        role="tab" aria-controls="manage-pane" aria-selected="true"><%= t('downloaders.index.manage_tab_label') %></button>
+    </li>
+
+    <%# Summary of access tab %>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="access-tab" data-bs-toggle="tab" data-bs-target="#access-pane" type="button"
+        role="tab" aria-controls="access-pane" aria-selected="false"><%= t('downloaders.index.summary_tab_label') %></button>
+    </li>
+  </ul>
+
+  <turbo-frame id="access-frame">
+    <div class="tab-content" id="downloaders-tabs-content">
+      <%# Manage access tab %>
+      <div class="tab-pane fade show active" id="manage-pane" role="tabpanel" aria-labelledby="manage-tab">
+        <%= render Downloaders::AdministerAccessComponent.new(organization: @organization) %>
+      </div>
+
+      <%# Summary of access tab %>
+      <div class="tab-pane fade" id="access-pane" role="tabpanel" aria-labelledby="access-tab">
+        <%= render Downloaders::AccessSummaryTableComponent.new(organization: @organization) %>
+      </div>
+    </div>
+  </turbo-frame>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,26 @@ en:
       restricted_group_access: "%{org_name} has restrictions set, allowing access to specific groups."
       restricted_group_and_org_access: "%{org_name} has restrictions set, allowing access to specific organizations and groups."
       restricted_org_access: "%{org_name} has restrictions set, allowing access to specific organizations."
-      unrestricted_access: "%{org_name} is currently unrestricted. Any POD organization can harvest its data."
+      unrestricted_access: "%{org_name} is currently unrestricted. Any POD organization can access its data."
+    access_summary_table_component:
+      description_html: The table below shows which organizations have access to records from %{org_name} and which organizations have granted %{org_name} access to their records.
+      heading_html: Access summary
+      table_heading:
+        access: Can access records from %{org_name}?
+        accessible: "%{org_name} can access records?"
+        grantee_reason: Summary of access granted to %{org_name}
+        grantor_reason: Summary of access granted by %{org_name}
+        organization: Organization
+    access_summary_table_data_component:
+      explanation:
+        granted_through_groups: Access granted to %{grantee_name} through its %{groups} membership
+        granted_to_org_and_group: Access granted directly to %{grantee_name} and through its %{groups} membership
+        granted_to_organization: Access granted directly to %{grantee_name}
+        no_access_granted: No access granted to %{grantee_name}
+        unrestricted_access: "%{grantor_name} has no restrictions set"
+    accessible_summary_table_data_component:
+      explanation:
+        not_a_provider: "%{grantor_name} is not a data provider"
     administer_access_component:
       heading: Access settings
     create:
@@ -42,6 +61,8 @@ en:
       success: Access was successfully revoked.
     index:
       heading: Access restrictions
+      manage_tab_label: Access settings
+      summary_tab_label: Access summary
     restrict_downloads_form_component:
       form_text: Choose whether to allow any POD organization to download records from your organization, or restrict access to specific organizations and groups.
       restricted_option: Restricted - Only allow specific organizations and groups to download records

--- a/spec/components/downloaders/access_summary_alert_component_spec.rb
+++ b/spec/components/downloaders/access_summary_alert_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Downloaders::AccessSummaryAlertComponent, type: :component do
     end
 
     it 'displays unrestricted access message' do
-      expect(rendered.text).to include('Test Org is currently unrestricted. Any POD organization can harvest its data')
+      expect(rendered.text).to include('Test Org is currently unrestricted. Any POD organization can access its data')
     end
   end
 

--- a/spec/components/downloaders/access_summary_table_component_spec.rb
+++ b/spec/components/downloaders/access_summary_table_component_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Downloaders::AccessSummaryTableComponent, type: :component do
+  subject(:rendered) do
+    Capybara::Node::Simple.new(render_inline(described_class.new(organization: organization)).to_html)
+  end
+
+  let(:organization) { create(:organization, name: 'Test Org') }
+  let(:user) { create(:user) }
+
+  # rubocop:disable RSpec/AnyInstance
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:current_ability).and_return(Ability.new(user))
+    Organization.create(name: 'Other Org 1')
+  end
+  # rubocop:enable RSpec/AnyInstance
+
+  it 'renders a table header' do # rubocop:disable RSpec/MultipleExpectations
+    expect(rendered).to have_css('th', text: 'Organization')
+    expect(rendered).to have_css('th', text: 'Can access records from Test Org?')
+    expect(rendered).to have_css('th', text: 'Summary of access granted by Test Org')
+    expect(rendered).to have_css('th', text: 'Test Org can access records?')
+    expect(rendered).to have_css('th', text: 'Summary of access granted to Test Org')
+  end
+end

--- a/spec/components/downloaders/access_summary_table_data_component_spec.rb
+++ b/spec/components/downloaders/access_summary_table_data_component_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Downloaders::AccessSummaryTableDataComponent, type: :component do
+  subject(:rendered) do
+    Capybara::Node::Simple.new(render_inline(described_class.new(organization: organization, other_org: other_org)).to_html)
+  end
+
+  let(:organization) { create(:organization, name: 'Test Org') }
+  let(:other_org) { create(:organization, name: 'Other Org') }
+
+  context 'when unrestricted access is allowed' do
+    before do
+      organization.update(restrict_downloads: false)
+    end
+
+    it 'renders the unrestricted access explanation' do
+      expect(rendered.text).to include('Test Org has no restrictions set')
+      expect(rendered).to have_css('i', class: 'can_access')
+    end
+  end
+
+  context 'when access is restricted and granted directly' do
+    before do
+      organization.update(restrict_downloads: true)
+      organization.downloader_organizations << other_org
+    end
+
+    it 'renders the direct access explanation' do
+      expect(rendered.text).to include('Access granted directly to Other Org')
+      expect(rendered).to have_css('i', class: 'can_access')
+    end
+  end
+
+  context 'when access is restricted and granted via group membership' do
+    let(:group) { create(:group, name: 'Test Group') }
+
+    before do
+      organization.update(restrict_downloads: true)
+      organization.downloader_groups << group
+      other_org.groups << group
+    end
+
+    it 'renders the group membership access explanation' do
+      expect(rendered.text).to include("Access granted to Other Org through its #{group.display_name} membership")
+      expect(rendered).to have_css('i', class: 'can_access')
+    end
+  end
+end

--- a/spec/components/downloaders/access_summary_table_row_component_spec.rb
+++ b/spec/components/downloaders/access_summary_table_row_component_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Downloaders::AccessSummaryTableRowComponent, type: :component do
+  subject(:rendered) do
+    Capybara::Node::Simple.new(render_inline(described_class.new(organization: organization, other_org: other_org)).to_html)
+  end
+
+  let(:organization) { create(:organization, name: 'Test Org') }
+  let(:other_org) { create(:organization, name: 'Other Org') }
+
+  it 'renders a table row with organization names and access information' do # rubocop:disable RSpec/MultipleExpectations
+    expect(rendered).to have_css('a', text: 'Other Org')
+    expect(rendered).to have_css('i', class: 'cannot_access')
+    expect(rendered.text).to include('No access granted to Other Org')
+  end
+end

--- a/spec/components/downloaders/accessible_summary_table_data_component_spec.rb
+++ b/spec/components/downloaders/accessible_summary_table_data_component_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Downloaders::AccessibleSummaryTableDataComponent, type: :component do
+  subject(:rendered) do
+    Capybara::Node::Simple.new(render_inline(described_class.new(organization: organization, other_org: other_org)).to_html)
+  end
+
+  let(:organization) { create(:organization, name: 'Test Org') }
+  let(:other_org) { create(:organization, name: 'Other Org') }
+
+  context 'when unrestricted access is allowed' do
+    before do
+      other_org.update(restrict_downloads: false)
+    end
+
+    it 'renders the unrestricted access explanation' do
+      expect(rendered.text).to include('Other Org has no restrictions set')
+      expect(rendered).to have_css('i', class: 'can_access')
+    end
+  end
+
+  context 'when access is restricted and granted directly' do
+    before do
+      other_org.update(restrict_downloads: true)
+      other_org.downloader_organizations << organization
+    end
+
+    it 'renders the direct access explanation' do
+      expect(rendered.text).to include('Access granted directly to Test Org')
+      expect(rendered).to have_css('i', class: 'can_access')
+    end
+  end
+
+  context 'when access is restricted and granted via group membership' do
+    let(:group) { create(:group, name: 'Test Group') }
+
+    before do
+      other_org.update(restrict_downloads: true)
+      other_org.downloader_groups << group
+      organization.groups << group
+    end
+
+    it 'renders the group membership access explanation' do
+      expect(rendered.text).to include("Access granted to Test Org through its #{group.display_name} membership")
+      expect(rendered).to have_css('i', class: 'can_access')
+    end
+  end
+end

--- a/spec/views/downloaders/index.html.erb_spec.rb
+++ b/spec/views/downloaders/index.html.erb_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe 'downloaders/index' do
     expect(rendered).to have_css('h3', text: 'Access restrictions')
   end
 
+  it 'renders a tab to view access summary information' do
+    render
+    expect(rendered).to have_button('Access summary')
+  end
+
   context 'when the user is an owner' do
     before do
       allow(Settings).to receive(:allow_organization_owners_to_manage_access).and_return(true)


### PR DESCRIPTION
Part of #1291 

Adds a tabbed interface to see a summary of access both granted and received for an organization.
<img width="1338" height="602" alt="Screenshot 2025-11-19 at 4 44 40 PM" src="https://github.com/user-attachments/assets/4d601618-3937-42cb-a81c-5a84359fcf4e" />

It would be nice if this updated live as changes were made, but it's a bit fiddly and I'd rather address that as follow up work.
