### PR TITLE
Check upload read ability before rendering link on upload activity

### DIFF
--- a/app/components/activity/uploads_tab_component.html.erb
+++ b/app/components/activity/uploads_tab_component.html.erb
@@ -30,7 +30,7 @@
           <td>
             <% if upload = uploads.first || provider.latest_upload %>
               <%= render StatusIcons::UploadStatusIconComponent.new(status: upload.metadata_status) %>
-              <%= link_to helpers.local_time(upload.created_at, format: helpers.datetime_display_format()), organization_upload_path(provider, upload) %>
+              <%= link_to_if helpers.can?(:read, upload), helpers.local_time(upload.created_at, format: helpers.datetime_display_format()), organization_upload_path(provider, upload) %>
             <% else %>
               <i class="bi bi-exclamation-triangle-fill text-warning pod-icon"></i>
             <% end %>


### PR DESCRIPTION
Don't link to uploads you can't read, Duke below:

<img width="1188" height="156" alt="Screenshot 2025-11-21 at 1 32 33 PM" src="https://github.com/user-attachments/assets/8191cab2-9080-45f3-afd5-8bb97043507e" />
