### PR TITLE
Add a download status icon that reflects the current user's access to an organization

### DIFF
--- a/app/components/status_icons/download_access_lock_icon_component.rb
+++ b/app/components/status_icons/download_access_lock_icon_component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module StatusIcons
+  # Download access status icon component
+  class DownloadAccessLockIconComponent < StatusIconComponent
+    def settings_data
+      Settings.download_access_lock_status
+    end
+  end
+end

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -8,6 +8,7 @@
   <table class="table table-striped organizations mt-4" id="providers">
     <thead>
       <tr>
+        <th><span class="visually-hidden">Download access</span></th>
         <th><span class="visually-hidden">Icon</span></th>
         <th>Provider</th>
         <th class="text-end files-column">Files</th>
@@ -25,6 +26,11 @@
       <% @providers.each do |organization| %>
         <% next unless can? :read, organization %>
         <tr>
+          <td class="align-middle text-center icon-column">
+            <%= link_to organization_downloaders_path(organization) do %>
+              <%= StatusIcons::DownloadAccessLockIconComponent.new(status: can?(:read, organization.default_stream) ? 'can_access' : 'cannot_access', classes:'').call %>
+            <% end %>
+          </td>
           <td class="align-middle text-center icon-column">
             <% if organization.icon.attached? %>
               <%= link_to image_tag(organization.icon, alt: '', class: 'icon-sm'), organization, aria: { hidden: true } %>

--- a/app/views/streams/_header.html.erb
+++ b/app/views/streams/_header.html.erb
@@ -1,8 +1,8 @@
 <div class="d-flex align-items-center">
+  <%= link_to organization_downloaders_path(stream.organization) do %>
+    <%= StatusIcons::DownloadAccessLockIconComponent.new(status: can?(:read, stream) ? 'can_access' : 'cannot_access', classes:'h2 pe-2').call %>
+  <% end %>
   <h2 class="font-weight-normal mb-0">
-    <% if stream.organization.restrict_downloads? %>
-      <i class="bi bi-lock-fill text-warning" title="Downloads are restricted to organization members only"></i>
-    <% end %>
     Stream: <%= stream.display_name %>
   </h2>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -78,6 +78,14 @@ download_access_status:
     icon_class: 'bi bi-dash'
     label: 'Cannot download records'
 
+download_access_lock_status:
+  can_access:
+    icon_class: 'bi bi-unlock2-fill text-success'
+    label: 'Can download records'
+  cannot_access:
+    icon_class: 'bi bi-lock-fill text-danger'
+    label: 'Cannot download records'
+
 # max. MARC records per OAI-XML file; also max. size of one page in ListRecords
 oai_max_page_size: 5000
 


### PR DESCRIPTION
Here's a stab at showing to the current user whether they can access a particular organization's records. Unlike the summary tables on the downloaders page it reflects the current user's access and links to the downloaders page in case they want more information.
<img width="826" height="456" alt="Screenshot 2025-11-21 at 2 32 40 PM" src="https://github.com/user-attachments/assets/4520bfe3-c607-4344-ab00-d8aae523a03b" />
<img width="876" height="275" alt="Screenshot 2025-11-21 at 2 32 48 PM" src="https://github.com/user-attachments/assets/8ca6bbb3-bba3-4a60-be63-a5c571cc58f6" />