### PR TITLE
Add some padding around Access restriction page components

### DIFF
--- a/app/views/downloaders/index.html.erb
+++ b/app/views/downloaders/index.html.erb
@@ -1,7 +1,12 @@
 <%= render 'shared/layout_manage_organization' do %>
   <h3><%= t('downloaders.index.heading') %></h3>
-  <%= render Downloaders::AccessSummaryAlertComponent.new(organization: @organization) %>
-  <%= render Downloaders::RestrictDownloadsFormComponent.new(organization: @organization) %>
+  <div class="pt-4">
+    <%= render Downloaders::AccessSummaryAlertComponent.new(organization: @organization) %>
+  </div>
+
+  <div class="pt-4 pb-3">
+    <%= render Downloaders::RestrictDownloadsFormComponent.new(organization: @organization) %>
+  </div>
 
   <% if @organization.provider? %>
     <ul class="nav nav-tabs pt-4" id="downloaders-tabs" role="tablist">


### PR DESCRIPTION
Before:
<img width="702" height="529" alt="Screenshot 2025-11-21 at 3 00 22 PM" src="https://github.com/user-attachments/assets/6b240b91-204c-4764-937d-469df8055eba" />

After:
<img width="744" height="610" alt="Screenshot 2025-11-21 at 2 58 46 PM" src="https://github.com/user-attachments/assets/7cf87182-6022-4b11-a4a4-e26ba70b1686" />
