### PR TITLE
Add padding in the components so things don't look bad when they don't render

### DIFF
--- a/app/components/downloaders/access_summary_alert_component.html.erb
+++ b/app/components/downloaders/access_summary_alert_component.html.erb
@@ -1,3 +1,3 @@
-<div id="access-summary-alert" class="alert alert-info" role="alert">
+<div id="access-summary-alert" class="alert alert-info mt-4" role="alert">
   <%= alert_text %>
 </div>

--- a/app/components/downloaders/restrict_downloads_form_component.html.erb
+++ b/app/components/downloaders/restrict_downloads_form_component.html.erb
@@ -1,4 +1,4 @@
-<%= helpers.bootstrap_form_with(model: @organization, url: organization_path(@organization), html: { method: :patch }) do |f| %>
+<%= helpers.bootstrap_form_with(model: @organization, url: organization_path(@organization), html: { method: :patch, class: 'pt-4 pb-3' }) do |f| %>
   <div class="mb-3">
     <%= f.select :restrict_downloads, options_for_select([[t('downloaders.restrict_downloads_form_component.unrestricted_option'), false],
                                                           [t('downloaders.restrict_downloads_form_component.restricted_option'), true]],

--- a/app/views/downloaders/index.html.erb
+++ b/app/views/downloaders/index.html.erb
@@ -1,12 +1,7 @@
 <%= render 'shared/layout_manage_organization' do %>
   <h3><%= t('downloaders.index.heading') %></h3>
-  <div class="pt-4">
     <%= render Downloaders::AccessSummaryAlertComponent.new(organization: @organization) %>
-  </div>
-
-  <div class="pt-4 pb-3">
     <%= render Downloaders::RestrictDownloadsFormComponent.new(organization: @organization) %>
-  </div>
 
   <% if @organization.provider? %>
     <ul class="nav nav-tabs pt-4" id="downloaders-tabs" role="tablist">


### PR DESCRIPTION
Sigh...what I did before looks bad on the consumer-only downloader pages because these components don't render. So moving the bootstrap classes to the component fixes the problem. Not ideal if we start displaying these elsewhere, but probably fine.