### PR TITLE
Turn off scheduled full dump job

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -598,6 +598,7 @@ PLATFORMS
   arm-linux-musl
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -19,9 +19,9 @@ production:
   delta_dump:
     command: "GenerateDeltaDumpJob.enqueue_all"
     schedule: every day at 03:40
-  full_dump:
-    command: "GenerateFullDumpJob.enqueue_some"
-    schedule: every 2 days
+  # full_dump:
+  #   command: "GenerateFullDumpJob.enqueue_some"
+  #   schedule: every 2 days
   remove_data:
     command: "CleanupAndRemoveDataJob.enqueue_all"
     schedule: every wednesday


### PR DESCRIPTION
Stopping scheduled full dump jobs until https://github.com/pod4lib/aggregator/issues/1541 is fixed.